### PR TITLE
Use mixed-case "Memory.h"

### DIFF
--- a/src/Memory.cpp
+++ b/src/Memory.cpp
@@ -6,7 +6,7 @@
 
 #include <stdio.h> // swprintf
 #include <stdlib.h>
-#include "memory.h"
+#include "Memory.h"
 
 void *NewP(size_t bytes) {	
 	void *ptr = malloc(bytes);	


### PR DESCRIPTION
This should have been part of earlier mixed-case changes - it was missed
because glibc ships a /usr/include/memory.h (with unrelated content).