### PR TITLE
Fix three bugs found in issue 20

### DIFF
--- a/src/CvtManager.cpp
+++ b/src/CvtManager.cpp
@@ -231,7 +231,7 @@ bool Attribute::InsertByName(Attribute **tree, bool predefined, const wchar_t na
 
 	if (!(*tree)) {
 		*tree = new Attribute;
-		if (!(*tree)) { swprintf(errMsg,L"Insufficient memory to define attribute \x22%s\x22",name); return false; }
+		if (!(*tree)) { swprintf(errMsg,L"Insufficient memory to define attribute \x22" WIDE_STR_FORMAT L"\x22",name); return false; }
 		(*tree)->predefined = predefined;
 		AssignString((*tree)->name,name,cvtAttributeStrgLen);
 		if (spacingText) AssignString((*tree)->spacingText,spacingText,cvtAttributeStrgLen);
@@ -240,7 +240,7 @@ bool Attribute::InsertByName(Attribute **tree, bool predefined, const wchar_t na
 		return true;
 	} else {
 		cmp = CompareCapString(name,(*tree)->name,cvtAttributeStrgLen);
-		if (!cmp) { swprintf(errMsg,L"Attribute \x22%s\x22 %sdefined",(*tree)->name,(*tree)->predefined ? L"is pre-" : L"already "); return false; }
+		if (!cmp) { swprintf(errMsg,L"Attribute \x22" WIDE_STR_FORMAT L"\x22 " WIDE_STR_FORMAT L"defined",(*tree)->name,(*tree)->predefined ? L"is pre-" : L"already "); return false; }
 		return Attribute::InsertByName(cmp < 0 ? &(*tree)->left : &(*tree)->right,predefined,name,spacingText,subAttribute,value,errMsg);
 	}
 } // Attribute::InsertByName
@@ -258,7 +258,7 @@ bool Attribute::SearchByName(Attribute *tree, wchar_t name[], wchar_t actualName
 		}
 		tree = cmp < 0 ? tree->left : tree->right;
 	}
-	swprintf(errMsg,L"Attribute \x22%s\x22 not defined",name); return false;
+	swprintf(errMsg,L"Attribute \x22" WIDE_STR_FORMAT L"\x22 not defined",name); return false;
 } // Attribute::SearchByName
 
 #define PackKey(subAttribute,value) ((int32_t)(subAttribute) << subAttributeBits | (value))
@@ -268,7 +268,7 @@ bool Attribute::InsertByValue(Attribute **tree, Symbol subAttribute, int32_t val
 
 	if (!(*tree)) {
 		*tree = new Attribute;
-		if (!(*tree)) { swprintf(errMsg,L"Insufficient memory to insert attribute \x22%s\x22",name); return false; }
+		if (!(*tree)) { swprintf(errMsg,L"Insufficient memory to insert attribute \x22" WIDE_STR_FORMAT L"\x22",name); return false; }
 		AssignString((*tree)->name,name,cvtAttributeStrgLen);
 		AssignString((*tree)->spacingText,spacingText,cvtAttributeStrgLen);
 		(*tree)->subAttribute = subAttribute;
@@ -276,7 +276,7 @@ bool Attribute::InsertByValue(Attribute **tree, Symbol subAttribute, int32_t val
 		return true;
 	} else {
 		key = PackKey(subAttribute,value); thisKey = PackKey((*tree)->subAttribute,(*tree)->value);
-		if (key == thisKey) { swprintf(errMsg,L"Attribute \x22%s\x22 already inserted",name); return false; } // not expected by now, though
+		if (key == thisKey) { swprintf(errMsg,L"Attribute \x22" WIDE_STR_FORMAT L"\x22 already inserted",name); return false; } // not expected by now, though
 		return Attribute::InsertByValue(key < thisKey ? &(*tree)->left : &(*tree)->right,subAttribute,value,name,spacingText,errMsg);
 	}
 } // Attribute::InsertByValue
@@ -293,7 +293,7 @@ bool Attribute::SearchByValue(Attribute *tree, Symbol subAttribute, int32_t valu
 		}
 		tree = key < thisKey ? tree->left : tree->right;
 	}
-	swprintf(errMsg,L"Attribute \x22%s\x22 not defined",name); return false;
+	swprintf(errMsg,L"Attribute \x22" WIDE_STR_FORMAT L"\x22 not defined",name); return false;
 } // Attribute::SearchByValue
 
 bool Attribute::SortByValue(Attribute **to, Attribute *from, wchar_t errMsg[]) {
@@ -712,16 +712,16 @@ void Scanner::ErrUnGetSym(void) {
 } // Scanner::ErrUnGetSym
 
 bool AssertNatural(ActParam *actParam, int32_t low, int32_t high, const wchar_t name[], wchar_t errMsg[]) {
-	if (actParam->type != naturalN) { swprintf(errMsg,L"%s expected (must be an integer in range %li through %li)",name,low,high); return false; }
+	if (actParam->type != naturalN) { swprintf(errMsg,WIDE_STR_FORMAT L" expected (must be an integer in range %li through %li)",name,low,high); return false; }
 	actParam->value >>= places6;
-	if (actParam->value < low || high < actParam->value) { swprintf(errMsg,L"%s out of range (must be in range %li through %li)",name,low,high); return false; }
+	if (actParam->value < low || high < actParam->value) { swprintf(errMsg,WIDE_STR_FORMAT L" out of range (must be in range %li through %li)",name,low,high); return false; }
 	return true; // by now
 } // AssertNatural
 
 bool AssertPixelAmount(ActParam *actParam, F26Dot6 low, F26Dot6 high, const wchar_t name[], wchar_t errMsg[]) {
 	if (actParam->type == naturalN) actParam->type = rationalN;
-	if (actParam->type != rationalN) { swprintf(errMsg,L"%s expected (must be a pixel amount in range %8.6f through %8.6f)",name,(double)low/one6,(double)high/one6); return false; }
-	if (actParam->value < low || high < actParam->value) { swprintf(errMsg,L"%s expected (must be in range %8.6f through %8.6f)",name,(double)low/one6,(double)high/one6); return false; }
+	if (actParam->type != rationalN) { swprintf(errMsg,WIDE_STR_FORMAT L" expected (must be a pixel amount in range %8.6f through %8.6f)",name,(double)low/one6,(double)high/one6); return false; }
+	if (actParam->value < low || high < actParam->value) { swprintf(errMsg,WIDE_STR_FORMAT L" expected (must be in range %8.6f through %8.6f)",name,(double)low/one6,(double)high/one6); return false; }
 	return true; // by now
 } // AssertPixelAmount
 
@@ -732,8 +732,8 @@ bool PrivateControlValueTable::AttributeDeclaration(int32_t firstAvailSubAttribu
 	this->newSyntax = true;
 	sym = this->scanner.sym;
 	if (!this->scanner.GetSym()) return false;
-	if (this->scanner.sym != ident) { swprintf(errMsg,L"%s name expected",keyWord[sym]); return false; }
-	if (firstAvailSubAttributeValue[sym] >= maxSubAttributes) { swprintf(errMsg,L"%s name exceeds capacity (cannot have more than %li)",keyWord[sym],maxSubAttributes); return false; }
+	if (this->scanner.sym != ident) { swprintf(errMsg,WIDE_STR_FORMAT L" name expected",keyWord[sym]); return false; }
+	if (firstAvailSubAttributeValue[sym] >= maxSubAttributes) { swprintf(errMsg,WIDE_STR_FORMAT L" name exceeds capacity (cannot have more than %li)",keyWord[sym],maxSubAttributes); return false; }
 	AssignString(name,this->scanner.literal,cvtAttributeStrgLen);
 	if (!this->scanner.GetSym()) return false;
 	spacingText[0] = L'\0';
@@ -754,11 +754,11 @@ bool PrivateControlValueTable::SettingsDeclaration(void) {
 
 	this->newSyntax = true;
 	sym = this->scanner.sym;
-	if (this->tempSettings.defined[sym-firstSetting]) { swprintf(this->errMsg,L"%s already defined",keyWord[sym]); return false; }
+	if (this->tempSettings.defined[sym-firstSetting]) { swprintf(this->errMsg,WIDE_STR_FORMAT L" already defined",keyWord[sym]); return false; }
 	if (!this->scanner.GetSym()) return false;
 
 	if (this->legacyCompile || sym != fpgmBias) {
-	swprintf(comment,L"/* %s */",keyWord[sym]); this->tt->Emit(comment);
+	swprintf(comment,L"/* " WIDE_STR_FORMAT L" */",keyWord[sym]); this->tt->Emit(comment);
 	}
 
 	switch (sym) {
@@ -772,7 +772,7 @@ bool PrivateControlValueTable::SettingsDeclaration(void) {
 			this->tempSettings.defined[sym - firstSetting] = true;
 			break;
 		case dropOutCtrlOff:
-			if (this->tempSettings.defined[scanCtrl-firstSetting] || this->tempSettings.defined[scanType-firstSetting]) { swprintf(this->errMsg,L"Cannot use %s together with %s or %s",keyWord[sym],keyWord[scanCtrl],keyWord[scanType]); this->scanner.ErrUnGetSym(); return false; }
+			if (this->tempSettings.defined[scanCtrl-firstSetting] || this->tempSettings.defined[scanType-firstSetting]) { swprintf(this->errMsg,L"Cannot use " WIDE_STR_FORMAT L" together with " WIDE_STR_FORMAT L" or " WIDE_STR_FORMAT,keyWord[sym],keyWord[scanCtrl],keyWord[scanType]); this->scanner.ErrUnGetSym(); return false; }
 			dropOffParam.lowPpemSize = -1; dropOffParam.highPpemSize = maxPpemSize-1; // lowest permissible ppem size - 1
 			if (!this->Parameter(&dropOffParam)) return false;
 			if (dropOffParam.type != ppemN) { swprintf(this->errMsg,L"Drop-out control turn-off ppem size expected (must be an integer in range @%li through @%li)" BRK L"Drop-out control turn-off ppem size specifies the ppem size at and above which drop-out control is no longer turned on.",1,dropOffParam.highPpemSize); this->scanner.ErrUnGetSym(); return false; }
@@ -783,7 +783,7 @@ bool PrivateControlValueTable::SettingsDeclaration(void) {
 			this->tempSettings.defined[sym - firstSetting] = true;
 			break;
 		case scanCtrl:
-			if (this->tempSettings.defined[dropOutCtrlOff-firstSetting]) { swprintf(this->errMsg,L"Cannot use %s together with %s",keyWord[sym],keyWord[dropOutCtrlOff]); this->scanner.ErrUnGetSym(); return false; }
+			if (this->tempSettings.defined[dropOutCtrlOff-firstSetting]) { swprintf(this->errMsg,L"Cannot use " WIDE_STR_FORMAT L" together with " WIDE_STR_FORMAT,keyWord[sym],keyWord[dropOutCtrlOff]); this->scanner.ErrUnGetSym(); return false; }
 			if (this->scanner.sym != equals) { swprintf(this->errMsg,L"= expected"); return false; }
 			if (!this->scanner.GetSym()) return false;
 			if (!this->Parameter(&scanCtrlParam)) return false;
@@ -793,7 +793,7 @@ bool PrivateControlValueTable::SettingsDeclaration(void) {
 			this->tempSettings.defined[sym - firstSetting] = true;
 			break;
 		case scanType:
-			if (this->tempSettings.defined[dropOutCtrlOff-firstSetting]) { swprintf(this->errMsg,L"Cannot use %s together with %s",keyWord[sym],keyWord[dropOutCtrlOff]); return false; }
+			if (this->tempSettings.defined[dropOutCtrlOff-firstSetting]) { swprintf(this->errMsg,L"Cannot use " WIDE_STR_FORMAT L" together with " WIDE_STR_FORMAT,keyWord[sym],keyWord[dropOutCtrlOff]); return false; }
 			if (this->scanner.sym != equals) { swprintf(this->errMsg,L"= expected"); return false; }
 			if (!this->scanner.GetSym()) return false;
 			if (!this->Parameter(&scanTypeParam)) return false;
@@ -999,8 +999,8 @@ bool PrivateControlValueTable::DeltaDeclaration(int32_t cvtNum, ControlValue *cv
 	while (cvtDelta <= this->scanner.sym && this->scanner.sym <= gCvtDelta) {
 		this->newSyntax = true;
 		cmdColor = (DeltaColor)(this->scanner.sym-cvtDelta);
-		if (colorDeltaDone[cmdColor]) { swprintf(this->errMsg,L"Cannot have more than one %s command per control value" BRK \
-										 L"Please combine them to a single %s command. Example: %s(1 @18..20;22, -1 @ 24..25)",
+		if (colorDeltaDone[cmdColor]) { swprintf(this->errMsg,L"Cannot have more than one " WIDE_STR_FORMAT L" command per control value" BRK \
+										 L"Please combine them to a single " WIDE_STR_FORMAT L" command. Example: " WIDE_STR_FORMAT L"(1 @18..20;22, -1 @ 24..25)",
 										  keyWord[this->scanner.sym],keyWord[this->scanner.sym],keyWord[this->scanner.sym]); return false; }
 		colorDeltaDone[cmdColor] = true;
 		if (!this->scanner.GetSym()) return false;
@@ -1062,7 +1062,7 @@ bool ValidBinaryOperation(ActParam *a, ActParam *b, Symbol op, wchar_t errMsg[])
 	wchar_t opName[4][10] = {L"add",L"subtract",L"multiply",L"divide"};
 	
 	if (a->type < naturalN || rationalN < a->type || b->type < naturalN || rationalN < b->type) {
-		swprintf(errMsg,L"cannot %s these operands",opName[op-plus]); return false;
+		swprintf(errMsg,L"cannot " WIDE_STR_FORMAT L" these operands",opName[op-plus]); return false;
 	}
 	a->type = Max(a->type,b->type);
 	if (op == divide && a->type == naturalN && b->type == naturalN && b->value != 0 && a->value % b->value != 0) a->type = rationalN;
@@ -1251,7 +1251,7 @@ bool PrivateControlValueTable::Compile(TextBuffer*source, TextBuffer*prepText, b
 	
 	this->tt->Emit(L"/* auto-generated pre-program */");
 	DateTimeStrg(dateTime);
-	swprintf(comment,L"/* VTT %s compiler %s */",VTTVersionString,dateTime); 
+	swprintf(comment,L"/* VTT " WIDE_STR_FORMAT L" compiler " WIDE_STR_FORMAT L" */",VTTVersionString,dateTime); 
 	this->tt->Emit(comment);
 	this->tt->Emit(L"");
 
@@ -1283,19 +1283,19 @@ bool PrivateControlValueTable::Compile(TextBuffer*source, TextBuffer*prepText, b
 
 	// provide defaults for settings if necessary
 	if (!this->tempSettings.defined[instructionsOn-firstSetting]) {
-		swprintf(comment,L"/* %s (default) */",keyWord[instructionsOn]); this->tt->Emit(comment);
+		swprintf(comment,L"/* " WIDE_STR_FORMAT L" (default) */",keyWord[instructionsOn]); this->tt->Emit(comment);
 		this->tt->INSTCTRL(this->tempSettings.instructionsOnFromPpemSize,this->tempSettings.instructionsOnToPpemSize);
 	}
 	if (!this->tempSettings.defined[dropOutCtrlOff-firstSetting] && !this->tempSettings.defined[scanCtrl-firstSetting]) {
-		swprintf(comment,L"/* %s (default) */",keyWord[scanCtrl]); this->tt->Emit(comment);
+		swprintf(comment,L"/* " WIDE_STR_FORMAT L" (default) */",keyWord[scanCtrl]); this->tt->Emit(comment);
 		this->tt->SCANCTRL(this->tempSettings.scanCtrlFlags);
 	}
 	if (!this->tempSettings.defined[dropOutCtrlOff-firstSetting] && !this->tempSettings.defined[scanType-firstSetting]) {
-		swprintf(comment,L"/* %s (default) */",keyWord[scanType]); this->tt->Emit(comment);
+		swprintf(comment,L"/* " WIDE_STR_FORMAT L" (default) */",keyWord[scanType]); this->tt->Emit(comment);
 		this->tt->SCANTYPE(this->tempSettings.scanTypeFlags);
 	}
 	if (!this->tempSettings.defined[cvtCutIn-firstSetting]) {
-		swprintf(comment,L"/* %s (default) */",keyWord[cvtCutIn]); this->tt->Emit(comment);
+		swprintf(comment,L"/* " WIDE_STR_FORMAT L" (default) */",keyWord[cvtCutIn]); this->tt->Emit(comment);
 		this->tt->AssertFreeProjVector(yRomanDir); // so far, this may become aspect-ration dependent, or such like...
 		this->tt->SCVTCI(this->tempSettings.numCvtCutIns,this->tempSettings.cvtCutInPpemSize,this->tempSettings.cvtCutInValue);
 	}
@@ -1442,7 +1442,7 @@ bool PrivateControlValueTable::GetAttributeStrings(int32_t cvtNum, wchar_t charG
 	charGroup[0] = linkColor[0] = linkDirection[0] = cvtCategory[0] = relative[0] = L'\0';
 	if (!AttribExists(this,cvtNum)) return false;
 	PrivateControlValueTable::UnpackAttributeStrings(this->cpgmData[cvtNum].attribute,charGroup,linkColor,linkDirection,cvtCategory);
-	swprintf(relative,L"%s",this->cpgmData[cvtNum].flags & relativeValue ? L"relative" : L"absolute");
+	swprintf(relative,WIDE_STR_FORMAT,this->cpgmData[cvtNum].flags & relativeValue ? L"relative" : L"absolute");
 	return true;
 } // PrivateControlValueTable::GetAttributeStrings
 
@@ -1669,7 +1669,7 @@ bool PrivateControlValueTable::DumpControlValueTable(TextBuffer *text) {
 			pos = swprintf(dump,L"%4li: %6i",cvtNum,cvtValue);
 			if (this->CvtAttributesExist(cvtNum)) {
 				this->GetAttributeStrings(cvtNum,groupStrg,colorStrg,directionStrg,categoryStrg,relativeStrg);
-				pos += swprintf(&dump[pos],L" /* %s %s %s %s (%s) */",groupStrg,colorStrg,directionStrg,categoryStrg,relativeStrg);
+				pos += swprintf(&dump[pos],L" /* " WIDE_STR_FORMAT L" " WIDE_STR_FORMAT L" " WIDE_STR_FORMAT L" " WIDE_STR_FORMAT L" (" WIDE_STR_FORMAT L") */",groupStrg,colorStrg,directionStrg,categoryStrg,relativeStrg);
 			}
 			text->AppendLine(dump);
 		}
@@ -1699,13 +1699,13 @@ bool PrivateControlValueTable::CompileCharGroup(File *from, short platformID, un
 			col++;
 			if (!scanner.GetSym()) goto error;
 		}
-		if (col < 4) { swprintf(errMsg,L"%s number expected",col < 3 ? L"hexadecimal" : L"decimal"); goto error; }
+		if (col < 4) { swprintf(errMsg,WIDE_STR_FORMAT L" number expected",col < 3 ? L"hexadecimal" : L"decimal"); goto error; }
 		while (col < 6 && scanner.sym == ident) {
 			AssignString(data[col-4],scanner.literal,cvtAttributeStrgLen);
 			col++;
 			if (!scanner.GetSym()) goto error;
 		}
-		if (col < 6) { swprintf(errMsg,L"%s expected",col < 5 ? L"character group" : L"postscript name"); goto error; }
+		if (col < 6) { swprintf(errMsg,WIDE_STR_FORMAT L" expected",col < 5 ? L"character group" : L"postscript name"); goto error; }
 		if (!Attribute::SearchByName(groups,data[0],NULL,&subAttribute,&aGroup,errMsg) || subAttribute != group) goto error;
 		if (code[theCol] != unknownUnicode) toCharGroupOfCharCode[code[theCol]] = (unsigned char)aGroup;
 		row++;

--- a/src/CvtManager.cpp
+++ b/src/CvtManager.cpp
@@ -1164,7 +1164,7 @@ bool PrivateControlValueTable::PixelAtPpemRange(DeltaColor cmdColor, ActParam *a
 		this->scanner.GetSym();
 		this->Parameter(&colorParam);
 		if (colorParam.type != naturalN || DeltaColorOfByte((unsigned char)(colorParam.value/one6)) == illegalDelta) {
-			swprintf(this->errMsg,L"illegal delta color flag (can be %hs only)",AllDeltaColorBytes());
+			swprintf(this->errMsg,L"illegal delta color flag (can be " NARROW_STR_FORMAT L" only)",AllDeltaColorBytes());
 			this->scanner.ErrUnGetSym(); return false;
 		}
 		actParam->deltaColor = DeltaColorOfByte((unsigned char)(colorParam.value/one6));

--- a/src/Platform.cpp
+++ b/src/Platform.cpp
@@ -28,7 +28,7 @@ void DateTimeStrg(wchar_t strg[]) {
 	time(&dateTime);
 #ifndef _WIN32
        char *cstring = ctime(&dateTime);
-       mbstowcs(strg, cstring, strlen(cstring));
+       mbstowcs(strg, cstring, strlen(cstring) + 1 /* the final '\0' */);
 #else
 	STRCPYW(strg, _wctime(&dateTime));
 #endif

--- a/src/TMTParser.cpp
+++ b/src/TMTParser.cpp
@@ -391,10 +391,10 @@ void TMTSourceParser::Parse(bool *changedSrc, int32_t *errPos, int32_t *errLen, 
 		/*****
 		if (cmd == ::mainStrokeAngle || cmd == ::glyphStrokeAngle || cmd == setItalicStrokeAngle || cmd == setItalicStrokePhase) {
 			if (cmd == ::mainStrokeAngle && this->mainStrokeAngle || cmd == ::glyphStrokeAngle && this->glyphStrokeAngle || cmd == setItalicStrokeAngle && this->italicStrokeAngle || cmd == setItalicStrokePhase && this->italicStrokePhase) {
-				swprintf(errMsg,L"%s already used in this glyph",tmtCmd[cmd].name); this->ErrorMsg(contextual,errMsg);
+				swprintf(errMsg,WIDE_STR_FORMAT L" already used in this glyph",tmtCmd[cmd].name); this->ErrorMsg(contextual,errMsg);
 			}
 			if (cmd == ::mainStrokeAngle && this->glyphStrokeAngle || cmd == ::glyphStrokeAngle && this->mainStrokeAngle) {
-				swprintf(errMsg,L"Cannot use both %s and %s in the same glyph",tmtCmd[::mainStrokeAngle].name,tmtCmd[::glyphStrokeAngle].name); this->ErrorMsg(contextual,errMsg);
+				swprintf(errMsg,L"Cannot use both " WIDE_STR_FORMAT L" and " WIDE_STR_FORMAT L" in the same glyph",tmtCmd[::mainStrokeAngle].name,tmtCmd[::glyphStrokeAngle].name); this->ErrorMsg(contextual,errMsg);
 			}
 			if (cmd == ::mainStrokeAngle) this->mainStrokeAngle = true;
 			else if (cmd == ::glyphStrokeAngle) this->glyphStrokeAngle = true;
@@ -600,7 +600,7 @@ bool TMTSourceParser::MakeProjFreeVector(bool haveFlag, int32_t flagValue, bool 
 			}
 		}
 		if (pvOverrideError || fvOverrideError)
-			swprintf(errMsg, L"cannot override %s direction when using the italic or adjusted italic angle / or //", pvOverrideError ? L"projection" : L"freedom");
+			swprintf(errMsg, L"cannot override " WIDE_STR_FORMAT L" direction when using the italic or adjusted italic angle / or //", pvOverrideError ? L"projection" : L"freedom");
 	}
 	return !(pvOverrideError || fvOverrideError);
 } // TMTSourceParser::MakeProjFreeVector

--- a/src/TMTParser.cpp
+++ b/src/TMTParser.cpp
@@ -1679,7 +1679,7 @@ void TMTSourceParser::ValidateParameter(ActParam *actParam) {
 			break;
 		case colorN:
 			if (DeltaColorOfByte((unsigned char)(actParam->numValue/one6)) == illegalDelta) {
-				swprintf(errMsg,L"illegal delta color flag (can be %hs only)",AllDeltaColorBytes()); this->ErrorMsg(contextual,errMsg);
+				swprintf(errMsg,L"illegal delta color flag (can be " NARROW_STR_FORMAT L" only)",AllDeltaColorBytes()); this->ErrorMsg(contextual,errMsg);
 				actParam->numValue = 0;
 			}
 			break;

--- a/src/TTAssembler.cpp
+++ b/src/TTAssembler.cpp
@@ -863,7 +863,7 @@ void TT_JRpushON_ReplaceLabel(tt_JRtype  *JR,tt_LabelType *Label,short *argStore
 			 /* JR->jr[i]->aPtr[index] = delta; */
 			 argStore[index] = delta; 
 			 /*
-			 printf(L"\n JRlabel=%s JRipos = %hd, labeliPos= %hd, delta = %hd",
+			 printf(L"\n JRlabel=" WIDE_STR_FORMAT L" JRipos = %hd, labeliPos= %hd, delta = %hd",
 			 			JR->jr[i]->label,	JRiPos, labeliPos, delta );
 			 */
 	}

--- a/src/TTEngine.cpp
+++ b/src/TTEngine.cpp
@@ -422,7 +422,7 @@ void TTSourceEngine::AssertTTVonLine(TTVector ttv, short parent0, short parent1,
 			if (ttv == fv && ((proj->from == parent0 && proj->to == parent1) || (proj->from == parent1 && proj->to == parent0)) && proj->dir == dir) {
 				swprintf(buf,L"SFVTPV[]");
 			} else {
-				swprintf(buf,L"S%sVTL[%c], %hi, %hi",ttv == fv ? L"F" : (ttv == pv ? L"P" : L"DP"),dir == perpDiagDir ? L'R' : L'r',parent0,parent1);
+				swprintf(buf,L"S" WIDE_STR_FORMAT L"VTL[%c], %hi, %hi",ttv == fv ? L"F" : (ttv == pv ? L"P" : L"DP"),dir == perpDiagDir ? L'R' : L'r',parent0,parent1);
 			}
 			this->Emit(buf);
 			v->dir = dir; v->from = parent0; v->to = parent1;
@@ -1441,7 +1441,7 @@ void GenGuardCond(TextBuffer *text, AltCodePath path) {
 
 	swprintf(codePath,L"#PUSH, %i, 2",path); text->AppendLine(codePath);
 	text->AppendLine(L"RS[]");
-	swprintf(codePath,L"%sEQ[]",path < altCodePathMonochromeOnly ? L"N" : L"LT"); text->AppendLine(codePath);
+	swprintf(codePath,WIDE_STR_FORMAT L"EQ[]",path < altCodePathMonochromeOnly ? L"N" : L"LT"); text->AppendLine(codePath);
 } // GenGuardCond
 
 void GenTalkIf(TextBuffer *talk, AltCodePath path, int32_t fpgmBias) {

--- a/src/TTEngine.cpp
+++ b/src/TTEngine.cpp
@@ -379,16 +379,16 @@ void TTSourceEngine::AssertFreeProjVector(TTVDirection dir) {
 			swprintf(code,L"SVTCA[Y]");
 			break;
 		case xItalDir:
-			swprintf(code,L"CALL[], %li",this->fnBias + setTTVtoXItalDirFn);
+			swprintf(code,L"CALL[], %i",this->fnBias + setTTVtoXItalDirFn);
 			break;
 		case yItalDir:
-			swprintf(code,L"CALL[], %li",this->fnBias + setTTVtoYItalDirFn);
+			swprintf(code,L"CALL[], %i",this->fnBias + setTTVtoYItalDirFn);
 			break;
 		case xAdjItalDir:
-			swprintf(code,L"CALL[], %li",this->fnBias + setTTVtoXAdjItalDirFn);
+			swprintf(code,L"CALL[], %i",this->fnBias + setTTVtoXAdjItalDirFn);
 			break;
 		case yAdjItalDir:
-			swprintf(code,L"CALL[], %li",this->fnBias + setTTVtoYAdjItalDirFn);
+			swprintf(code,L"CALL[], %i",this->fnBias + setTTVtoYAdjItalDirFn);
 			break;
 		default:
 			swprintf(code,L"/* illegal TT vector direction */");
@@ -500,7 +500,7 @@ void TTSourceEngine::AssertMinDist(short minDists, short jumpPpemSize[], F26Dot6
 	switch (minDists) {
 		case 1:
 			if (this->minDist != pixelSize[0]) {
-				swprintf(buf,L"SMD[], %li",pixelSize[0]); this->Emit(buf);
+				swprintf(buf,L"SMD[], %i",pixelSize[0]); this->Emit(buf);
 				this->minDist = pixelSize[0];
 			}
 			break;
@@ -510,21 +510,21 @@ void TTSourceEngine::AssertMinDist(short minDists, short jumpPpemSize[], F26Dot6
 				swprintf(buf,L"GT[], %hi, *",jumpPpemSize[1]); this->Emit(buf);	// [TOS](= jumpPpemSize[1]) > [TOS-1](= MPPEM[]) ?
 				this->Emit( L"IF[], *");											// MPPEM[] < jumpPpemSize[1] ?
 				this->Emit( L"#BEGIN");											// but current minDist is pixelSize[1]
-				swprintf(buf,L"SMD[], %li",pixelSize[0]); this->Emit(buf);		// hence use pixelSize[0] instead
+				swprintf(buf,L"SMD[], %i",pixelSize[0]); this->Emit(buf);		// hence use pixelSize[0] instead
 			} else if (this->minDist == pixelSize[0]) {
 				swprintf(buf,L"LTEQ[], %hi, *",jumpPpemSize[1]); this->Emit(buf);	// [TOS](= jumpPpemSize[1]) ≤ [TOS-1](= MPPEM[]) ?
 				this->Emit( L"IF[], *");											// MPPEM[] ≥ jumpPpemSize[1]
 				this->Emit( L"#BEGIN");											// but current minDist is pixelSize[0]
-				swprintf(buf,L"SMD[], %li",pixelSize[1]); this->Emit(buf);		// use pixelSize[1] instead
+				swprintf(buf,L"SMD[], %i",pixelSize[1]); this->Emit(buf);		// use pixelSize[1] instead
 			} else {
 				swprintf(buf,L"GT[], %hi, *",jumpPpemSize[1]); this->Emit(buf);
 				this->Emit( L"IF[], *");
 				this->Emit( L"#BEGIN");
-				swprintf(buf,L"SMD[], %li",pixelSize[0]); this->Emit(buf);
+				swprintf(buf,L"SMD[], %i",pixelSize[0]); this->Emit(buf);
 				this->Emit( L"#END");
 				this->Emit( L"ELSE[]");
 				this->Emit( L"#BEGIN");
-				swprintf(buf,L"SMD[], %li",pixelSize[1]); this->Emit(buf);
+				swprintf(buf,L"SMD[], %i",pixelSize[1]); this->Emit(buf);
 			}
 			this->Emit(		L"#END");
 			this->Emit(		L"EIF[]");
@@ -712,7 +712,7 @@ void TTSourceEngine::SHPIX(short knots, short knot[], F26Dot6 amount) {
 	
 	swprintf(buf,L"SHPIX[]");
 	for (i = 0; i < knots; i++) swprintf(&buf[STRLENW(buf)],L", %hi",knot[i]);
-	swprintf(&buf[STRLENW(buf)],L", %li",amount);
+	swprintf(&buf[STRLENW(buf)],L", %i",amount);
 	this->Emit(buf);
 } // TTSourceEngine::SHPIX
 
@@ -886,25 +886,25 @@ void TTSourceEngine::DLT(bool cvt, DeltaColor color, short knot, F26Dot6 amount,
 			if (ppemRangeLow[size] == ppemRangeHigh[size])
 				if (color == alwaysDelta)
 					if (cvt)
-						swprintf(buf,L"CALL[], %li, %hi, %hi, %hi",amount,knot,ppemRangeLow[size],this->fnBias + deltaCvtSinglePpemFn);
+						swprintf(buf,L"CALL[], %i, %hi, %hi, %hi",amount,knot,ppemRangeLow[size],this->fnBias + deltaCvtSinglePpemFn);
 					else
-						swprintf(buf,L"CALL[], %hi, %li, %hi, %hi",knot,amount,ppemRangeLow[size],this->fnBias + deltaKnotSinglePpemFn);
+						swprintf(buf,L"CALL[], %hi, %i, %hi, %hi",knot,amount,ppemRangeLow[size],this->fnBias + deltaKnotSinglePpemFn);
 				else
 					if (cvt)
-						swprintf(buf,L"CALL[], %li, %hi, %hi, %hi, %hi",amount,knot,ppemRangeLow[size],ByteOfDeltaColor(color),this->fnBias + colorDeltaCvtSinglePpemFn);
+						swprintf(buf,L"CALL[], %i, %hi, %hi, %hi, %hi",amount,knot,ppemRangeLow[size],ByteOfDeltaColor(color),this->fnBias + colorDeltaCvtSinglePpemFn);
 					else
-						swprintf(buf,L"CALL[], %hi, %li, %hi, %hi, %hi",knot,amount,ppemRangeLow[size],ByteOfDeltaColor(color),this->fnBias + colorDeltaKnotSinglePpemFn);
+						swprintf(buf,L"CALL[], %hi, %i, %hi, %hi, %hi",knot,amount,ppemRangeLow[size],ByteOfDeltaColor(color),this->fnBias + colorDeltaKnotSinglePpemFn);
 			else
 				if (color == alwaysDelta)
 					if (cvt)
-						swprintf(buf,L"CALL[], %li, %hi, %hi, %hi, %hi",amount,knot,ppemRangeLow[size],ppemRangeHigh[size],this->fnBias + deltaCvtPpemRangeFn);
+						swprintf(buf,L"CALL[], %i, %hi, %hi, %hi, %hi",amount,knot,ppemRangeLow[size],ppemRangeHigh[size],this->fnBias + deltaCvtPpemRangeFn);
 					else
-						swprintf(buf,L"CALL[], %hi, %li, %hi, %hi, %hi",knot,amount,ppemRangeLow[size],ppemRangeHigh[size],this->fnBias + deltaKnotPpemRangeFn);
+						swprintf(buf,L"CALL[], %hi, %i, %hi, %hi, %hi",knot,amount,ppemRangeLow[size],ppemRangeHigh[size],this->fnBias + deltaKnotPpemRangeFn);
 				else
 					if (cvt)
-						swprintf(buf,L"CALL[], %li, %hi, %hi, %hi, %hi, %hi",amount,knot,ppemRangeLow[size],ppemRangeHigh[size],ByteOfDeltaColor(color),this->fnBias + colorDeltaCvtPpemRangeFn);
+						swprintf(buf,L"CALL[], %i, %hi, %hi, %hi, %hi, %hi",amount,knot,ppemRangeLow[size],ppemRangeHigh[size],ByteOfDeltaColor(color),this->fnBias + colorDeltaCvtPpemRangeFn);
 					else
-						swprintf(buf,L"CALL[], %hi, %li, %hi, %hi, %hi, %hi",knot,amount,ppemRangeLow[size],ppemRangeHigh[size],ByteOfDeltaColor(color),this->fnBias + colorDeltaKnotPpemRangeFn);
+						swprintf(buf,L"CALL[], %hi, %i, %hi, %hi, %hi, %hi",knot,amount,ppemRangeLow[size],ppemRangeHigh[size],ByteOfDeltaColor(color),this->fnBias + colorDeltaKnotPpemRangeFn);
 			this->Emit(buf);
 		}
 	}
@@ -1257,10 +1257,10 @@ void TTSourceEngine::SCVTCI(short numCvtCutIns, short cvtCutInPpemSize[], F26Dot
 	}
 
 	if (numCvtCutIns > 0) {
-		swprintf(code,L"SCVTCI[], %li",cvtCutInValue[0]); this->Emit(code);
+		swprintf(code,L"SCVTCI[], %i",cvtCutInValue[0]); this->Emit(code);
 		if (!this->legacyCompile)
 		{
-			swprintf(code, L"WS[], %li, %li", cvtCutInStorage, cvtCutInValue[0]); this->Emit(code);
+			swprintf(code, L"WS[], %i, %i", cvtCutInStorage, cvtCutInValue[0]); this->Emit(code);
 		}
 	}
 	if (numCvtCutIns > 1) {
@@ -1275,7 +1275,7 @@ void TTSourceEngine::SCVTCI(short numCvtCutIns, short cvtCutInPpemSize[], F26Dot
 					L"#PUSH, %hi" BRK
 					L"GTEQ[]" BRK
 					L"IF[]" BRK
-					L"#PUSH, %li, %li, %li" BRK
+					L"#PUSH, %i, %i, %i" BRK
 					L"SCVTCI[]" BRK
 					L"WS[]", cvtCutInPpemSize[cvtCutIn], cvtCutInStorage, cvtCutInValue[cvtCutIn], cvtCutInValue[cvtCutIn]);
 			}
@@ -1285,7 +1285,7 @@ void TTSourceEngine::SCVTCI(short numCvtCutIns, short cvtCutInPpemSize[], F26Dot
 					L"#PUSH, %hi" BRK
 					L"GTEQ[]" BRK
 					L"IF[]" BRK
-					L"#PUSH, %li" BRK
+					L"#PUSH, %i" BRK
 					L"SCVTCI[]",cvtCutInPpemSize[cvtCutIn],cvtCutInValue[cvtCutIn]);
 			}
 
@@ -1330,7 +1330,7 @@ void TTSourceEngine::SetClearTypeCtrl(short ctrl) {
 					  L"RS[]"              BRK
 					  L"LTEQ[]"            BRK
 					  L"IF[]"              BRK
-					  L"    #PUSH, %li, 3" BRK
+					  L"    #PUSH, %i, 3" BRK
 					  L"    INSTCTRL[]"    BRK
 					  L"EIF[]"             BRK
 					  L"#PUSHON"           BRK,4);
@@ -1439,7 +1439,7 @@ void GenGuardCond(TextBuffer *text, AltCodePath path) {
 
 	path = (AltCodePath)Min(Max(firstAltCodePath,path),lastAltCodePath);
 
-	swprintf(codePath,L"#PUSH, %li, 2",path); text->AppendLine(codePath);
+	swprintf(codePath,L"#PUSH, %i, 2",path); text->AppendLine(codePath);
 	text->AppendLine(L"RS[]");
 	swprintf(codePath,L"%sEQ[]",path < altCodePathMonochromeOnly ? L"N" : L"LT"); text->AppendLine(codePath);
 } // GenGuardCond
@@ -1455,7 +1455,7 @@ void GenTalkIf(TextBuffer *talk, AltCodePath path, int32_t fpgmBias) {
 	talk->AppendLine(L"#BEGIN");
 	talk->AppendLine(L"\x22)");
 	talk->AppendLine(L"");
-	swprintf(codePath,L"BeginCodePath(%li)",fpgmBias); talk->AppendLine(codePath);
+	swprintf(codePath,L"BeginCodePath(%i)",fpgmBias); talk->AppendLine(codePath);
 	talk->AppendLine(L"");
 } // GenTalkIf
 
@@ -1471,7 +1471,7 @@ void GenTalkElse(TextBuffer *talk, int32_t fpgmBias) {
 	talk->AppendLine(L"#BEGIN");
 	talk->AppendLine(L"\x22)");
 	talk->AppendLine(L"");
-	swprintf(codePath,L"BeginCodePath(%li)",fpgmBias); talk->AppendLine(codePath);
+	swprintf(codePath,L"BeginCodePath(%i)",fpgmBias); talk->AppendLine(codePath);
 	talk->AppendLine(L"");
 } // GenTalkElse
 
@@ -1489,7 +1489,7 @@ void GenPrepIf(TextBuffer *prep, AltCodePath path) {
 	wchar_t codePath[32];
 
 	prep->AppendLine(L"#PUSHOFF");
-	swprintf(codePath,L"#PUSH, %li",greyScalingFn); prep->AppendLine(codePath);
+	swprintf(codePath,L"#PUSH, %i",greyScalingFn); prep->AppendLine(codePath);
 	prep->AppendLine(L"CALL[]");
 	GenGuardCond(prep,path);
 	prep->AppendLine(L"IF[]");

--- a/src/TTFont.cpp
+++ b/src/TTFont.cpp
@@ -366,7 +366,7 @@ void TrueTypeFont::AssertMaxGlyphs(int32_t minGlyphs) {
 
 void MaxSfntSizeError(const wchar_t from[], int32_t size, wchar_t errMsg[]);
 void MaxSfntSizeError(const wchar_t from[], int32_t size, wchar_t errMsg[]) {
-	swprintf(errMsg,L"%s, \r" BULLET L" Unable to allocate %li to work on this font.",from, size);
+	swprintf(errMsg,WIDE_STR_FORMAT L", \r" BULLET L" Unable to allocate %li to work on this font.",from, size);
 } // MaxSfntSizeError
 
 bool TrueTypeFont::SetSfnt(short platformID, short encodingID, wchar_t errMsg[])
@@ -2250,7 +2250,7 @@ bool TrueTypeFont::UpdateMaxPointsAndContours(wchar_t errMsg[]) {
 
 	return true;
 failure:
-	swprintf(errMsg,L"Failed to update max points and contours due to %s table",failureMsg[failureCode]);
+	swprintf(errMsg,L"Failed to update max points and contours due to " WIDE_STR_FORMAT L" table",failureMsg[failureCode]);
 	return false;
 } // TrueTypeFont::UpdateMaxPointsAndContours
 
@@ -2389,7 +2389,7 @@ bool TrueTypeFont::GetSource(bool lowLevel, int32_t glyphIndex, TextBuffer *sour
 	{		
 		swprintf(errMsg,L"Unpacking source: ");
 		if (len == 0)
-			swprintf(&errMsg[STRLENW(errMsg)],L"private %slevel table empty",lowLevel ? L"low" : L"high");
+			swprintf(&errMsg[STRLENW(errMsg)],L"private " WIDE_STR_FORMAT L"level table empty",lowLevel ? L"low" : L"high");
 		else if (glitIndex == glitEntries)
 			swprintf(&errMsg[STRLENW(errMsg)],L"glyph %li not in private glit",glyphIndex);
 		else

--- a/src/TTFont.cpp
+++ b/src/TTFont.cpp
@@ -620,7 +620,7 @@ bool TrueTypeFont::GetCvt(TextBuffer *cvtText, wchar_t errMsg[]) {
 	if (!this->GetSource(true,CVT_GLYPH_INDEX,cvtText,errMsg)) return false;
 
 	if (cvtText->TheLength() == 0) { // decode binary cvt
-		for (i = 0; i < entries; i++) { swprintf(buffer,L"%li: %hi\r",i,SWAPW(cvt[i])); cvtText->Append(buffer); }
+		for (i = 0; i < entries; i++) { swprintf(buffer,L"%i: %hi\r",i,SWAPW(cvt[i])); cvtText->Append(buffer); }
 		
 	}
 	this->cvt->PutCvtBinary(size,(unsigned char *)cvt);

--- a/src/TTGenerator.cpp
+++ b/src/TTGenerator.cpp
@@ -1723,7 +1723,7 @@ void TTSourceGenerator::Serif(bool forward, short type, short knots, short knot[
 			italBase = this->italic && absVectProd < length*this->sinF22; // angle between base and yAxis < 2*MAXIMUM_ITALIC_ANGLE_DEVIATION
 			if (vertBase || horzBase || italBase) {
 				if (this->tt) {
-					swprintf(buf,L"/* %s serif %hi %hi %hi */",forward ? L"Forward" : L"Backward",knot[1],knot[2],knot[3]); this->tt->Emit(buf);
+					swprintf(buf,L"/* " WIDE_STR_FORMAT L" serif %hi %hi %hi */",forward ? L"Forward" : L"Backward",knot[1],knot[2],knot[3]); this->tt->Emit(buf);
 					if (horzBase && type == 2) { // seems to be some kind of optimisation for the frequent case of a simple serif such as in a Times 'I'...
 						cvt[0] = this->TheCvt(knot[3],knot[1],linkGrey,linkX,cvtSerifExt,   -1);
 						cvt[1] = this->TheCvt(knot[1],knot[2],linkGrey,linkY,cvtSerifThin,  -1);
@@ -1801,7 +1801,7 @@ void TTSourceGenerator::Serif(bool forward, short type, short knots, short knot[
 			if (vertBase || horzBase || italBase) {
 /* universal serif used by the new feature recognition */
 				if (this->tt) {
-					swprintf(buf,L"/* %s univ-serif %hi %hi %hi %hi */",forward ? L"Forward" : L"Backward",knot[1],knot[2],knot[3],knot[4]); this->tt->Emit(buf);
+					swprintf(buf,L"/* " WIDE_STR_FORMAT L" univ-serif %hi %hi %hi %hi */",forward ? L"Forward" : L"Backward",knot[1],knot[2],knot[3],knot[4]); this->tt->Emit(buf);
 					
 					this->Link(horzBase,false,horzBase ? &this->yRomanPV : &this->yRomanPV,false,knot[1],knot[3],cvtSerifThin,illegalCvtNum,1,ppem,dist,&actualCvt,error);
 					this->Link(!horzBase,false,!horzBase ? &this->yRomanPV : &this->yRomanPV,false,knot[4],knot[2],cvtSerifExt,illegalCvtNum,0,NULL,NULL,&actualCvt,error);
@@ -2034,7 +2034,7 @@ void TTSourceGenerator::InitTTGenerator(TrueTypeFont *font, TrueTypeGlyph *glyph
 		if (L' ' < this->charCode && this->charCode < 0x7f) { swprintf(&buf[STRLENW(buf)],L" (%c)",(wchar_t)this->charCode); }
 		swprintf(&buf[STRLENW(buf)],L" */");
 		this->tt->Emit(buf);
-		swprintf(buf,L"/* VTT %s compiler %s */",VTTVersionString,dateTime); this->tt->Emit(buf);
+		swprintf(buf,L"/* VTT " WIDE_STR_FORMAT L" compiler " WIDE_STR_FORMAT L" */",VTTVersionString,dateTime); this->tt->Emit(buf);
 	}
 } /* TTSourceGenerator::InitTTGenerator */
 

--- a/src/TTGenerator.cpp
+++ b/src/TTGenerator.cpp
@@ -2030,7 +2030,7 @@ void TTSourceGenerator::InitTTGenerator(TrueTypeFont *font, TrueTypeGlyph *glyph
 
 	if (this->tt) {
 		DateTimeStrg(dateTime);
-		swprintf(buf,L"/* TT glyph %li, char 0x%lx",this->glyphIndex,this->charCode);
+		swprintf(buf,L"/* TT glyph %i, char 0x%lx",this->glyphIndex,this->charCode);
 		if (L' ' < this->charCode && this->charCode < 0x7f) { swprintf(&buf[STRLENW(buf)],L" (%c)",(wchar_t)this->charCode); }
 		swprintf(&buf[STRLENW(buf)],L" */");
 		this->tt->Emit(buf);

--- a/src/pch.h
+++ b/src/pch.h
@@ -53,3 +53,13 @@
 #define swprintf(wcs, ...) swprintf(wcs, 1024, __VA_ARGS__)
 #define wprintf_s wprintf
 #endif
+
+#ifndef _MSC_VER
+/* ISO C Standard for *w*printf() */
+#define WIDE_STR_FORMAT L"%S"
+#define NARROW_STR_FORMAT L"%s"
+#else
+/* Microsoft compiler's w*printf() behavior */
+#define WIDE_STR_FORMAT L"%s"
+#define NARROW_STR_FORMAT L"%S"
+#endif

--- a/src/vttcompile.cpp
+++ b/src/vttcompile.cpp
@@ -183,7 +183,7 @@ bool Application::CompileCommon(int32_t* errPos, int32_t* errLen, wchar_t errMsg
 			this->font->UpdateAdvanceWidthFlag(this->font->TheCvt()->LinearAdvanceWidths());
 		}
 		else {
-			swprintf(tempErrMsg, L"Ctrl Pgm, line %li: %s", this->cpgm->LineNumOf(*errPos), compErrMsg);
+			swprintf(tempErrMsg, L"Ctrl Pgm, line %li: " WIDE_STR_FORMAT, this->cpgm->LineNumOf(*errPos), compErrMsg);
 			errBuf->AppendLine(tempErrMsg);
 		}
 	}
@@ -216,7 +216,7 @@ bool Application::CompileCommon(int32_t* errPos, int32_t* errLen, wchar_t errMsg
 			done = this->font->UpdateBinData(asmFPGM, binSize, binData);
 		else {
 			done = this->font->UpdateBinData(asmFPGM, 0, NULL);
-			swprintf(tempErrMsg, L"Font Pgm, line %li: %s", this->fpgm->LineNumOf(*errPos), compErrMsg);
+			swprintf(tempErrMsg, L"Font Pgm, line %li: " WIDE_STR_FORMAT, this->fpgm->LineNumOf(*errPos), compErrMsg);
 			errBuf->AppendLine(tempErrMsg);
 		}
 	}
@@ -226,7 +226,7 @@ bool Application::CompileCommon(int32_t* errPos, int32_t* errLen, wchar_t errMsg
 			done = this->font->UpdateBinData(asmPREP, binSize, binData);
 		else {
 			done = this->font->UpdateBinData(asmPREP, 0, NULL);
-			swprintf(tempErrMsg, L"Pre Pgm, line %li: %s", this->prep->LineNumOf(*errPos), compErrMsg);
+			swprintf(tempErrMsg, L"Pre Pgm, line %li: " WIDE_STR_FORMAT, this->prep->LineNumOf(*errPos), compErrMsg);
 			errBuf->AppendLine(tempErrMsg);
 		}
 	}
@@ -292,9 +292,9 @@ bool Application::CompileGlyphRange(unsigned short g1, unsigned short g2, int32_
 
 		if (done) {
 			if (!TMTCompile(this->talk.get(), this->font.get(), this->glyph.get(), this->glyphIndex, this->glyf.get(), legacyCompile, errPos, errLen, compErrMsg)) {
-				swprintf(tempErrMsg, L"VTT Talk, glyph %li (Unicode 0x%lx), line %li: %s", this->glyphIndex, this->charCode, this->talk->LineNumOf(*errPos), compErrMsg);
+				swprintf(tempErrMsg, L"VTT Talk, glyph %li (Unicode 0x%lx), line %li: " WIDE_STR_FORMAT, this->glyphIndex, this->charCode, this->talk->LineNumOf(*errPos), compErrMsg);
 				errBuf->AppendLine(tempErrMsg);
-				swprintf(tempErrMsg, L"/* Error in VTT Talk, line %li: %s */", this->talk->LineNumOf(*errPos), compErrMsg);
+				swprintf(tempErrMsg, L"/* Error in VTT Talk, line %li: " WIDE_STR_FORMAT L" */", this->talk->LineNumOf(*errPos), compErrMsg);
 				this->glyf->SetText((int32_t)STRLENW(tempErrMsg), tempErrMsg); // prevent follow-up errors
 			}
 		}
@@ -307,7 +307,7 @@ bool Application::CompileGlyphRange(unsigned short g1, unsigned short g2, int32_
 			else
 			{
 				done = this->font->UpdateBinData(asmGLYF, 0, NULL);
-				swprintf(tempErrMsg, L"Glyf Pgm, glyph %li (Unicode 0x%lx), line %li: %s", this->glyphIndex, this->charCode, this->glyf->LineNumOf(*errPos), compErrMsg);
+				swprintf(tempErrMsg, L"Glyf Pgm, glyph %li (Unicode 0x%lx), line %li: " WIDE_STR_FORMAT, this->glyphIndex, this->charCode, this->glyf->LineNumOf(*errPos), compErrMsg);
 				errBuf->AppendLine(tempErrMsg);
 			}
 		}
@@ -375,7 +375,7 @@ bool Application::CompileAll(int32_t* errPos, int32_t* errLen, bool quiet, wchar
 			this->font->UpdateAdvanceWidthFlag(this->font->TheCvt()->LinearAdvanceWidths());
 		}
 		else {
-			swprintf(tempErrMsg, L"Ctrl Pgm, line %li: %s", this->cpgm->LineNumOf(*errPos), compErrMsg);
+			swprintf(tempErrMsg, L"Ctrl Pgm, line %li: " WIDE_STR_FORMAT, this->cpgm->LineNumOf(*errPos), compErrMsg);
 			errBuf->AppendLine(tempErrMsg);
 		}
 	}
@@ -409,7 +409,7 @@ bool Application::CompileAll(int32_t* errPos, int32_t* errLen, bool quiet, wchar
 			done = this->font->UpdateBinData(asmFPGM, binSize, binData);
 		else {
 			done = this->font->UpdateBinData(asmFPGM, 0, NULL);
-			swprintf(tempErrMsg, L"Font Pgm, line %li: %s", this->fpgm->LineNumOf(*errPos), compErrMsg);
+			swprintf(tempErrMsg, L"Font Pgm, line %li: " WIDE_STR_FORMAT, this->fpgm->LineNumOf(*errPos), compErrMsg);
 			errBuf->AppendLine(tempErrMsg);
 		}
 	}
@@ -419,7 +419,7 @@ bool Application::CompileAll(int32_t* errPos, int32_t* errLen, bool quiet, wchar
 			done = this->font->UpdateBinData(asmPREP, binSize, binData);
 		else {
 			done = this->font->UpdateBinData(asmPREP, 0, NULL);
-			swprintf(tempErrMsg, L"Pre Pgm, line %li: %s", this->prep->LineNumOf(*errPos), compErrMsg);
+			swprintf(tempErrMsg, L"Pre Pgm, line %li: " WIDE_STR_FORMAT, this->prep->LineNumOf(*errPos), compErrMsg);
 			errBuf->AppendLine(tempErrMsg);
 		}
 	}
@@ -437,9 +437,9 @@ bool Application::CompileAll(int32_t* errPos, int32_t* errLen, bool quiet, wchar
 
 		if (done) {
 			if (!TMTCompile(this->talk.get(), this->font.get(), this->glyph.get(), this->glyphIndex, this->glyf.get(), legacyCompile, errPos, errLen, compErrMsg)) {
-				swprintf(tempErrMsg, L"VTT Talk, glyph %li (Unicode 0x%lx), line %li: %s", this->glyphIndex, this->charCode, this->talk->LineNumOf(*errPos), compErrMsg);
+				swprintf(tempErrMsg, L"VTT Talk, glyph %li (Unicode 0x%lx), line %li: " WIDE_STR_FORMAT, this->glyphIndex, this->charCode, this->talk->LineNumOf(*errPos), compErrMsg);
 				errBuf->AppendLine(tempErrMsg);
-				swprintf(tempErrMsg, L"/* Error in VTT Talk, line %li: %s */", this->talk->LineNumOf(*errPos), compErrMsg);
+				swprintf(tempErrMsg, L"/* Error in VTT Talk, line %li: " WIDE_STR_FORMAT L" */", this->talk->LineNumOf(*errPos), compErrMsg);
 				this->glyf->SetText((int32_t)STRLENW(tempErrMsg), tempErrMsg); // prevent follow-up errors
 			}
 		}
@@ -447,7 +447,7 @@ bool Application::CompileAll(int32_t* errPos, int32_t* errLen, bool quiet, wchar
 		binSize = 0;
 		if (done) {
 			if (!TTAssemble(asmGLYF, this->glyf.get(), this->font.get(), this->glyph.get(), MAXBINSIZE, binData, &binSize, variationCompositeGuard, errPos, errLen, compErrMsg)) {
-				swprintf(tempErrMsg, L"Glyf Pgm, glyph %li (Unicode 0x%lx), line %li: %s", this->glyphIndex, this->charCode, this->glyf->LineNumOf(*errPos), compErrMsg);
+				swprintf(tempErrMsg, L"Glyf Pgm, glyph %li (Unicode 0x%lx), line %li: " WIDE_STR_FORMAT, this->glyphIndex, this->charCode, this->glyf->LineNumOf(*errPos), compErrMsg);
 				errBuf->AppendLine(tempErrMsg);
 			}
 		}
@@ -505,7 +505,7 @@ int ShowUsage(wchar_t* strErr)
 {
 	if (strErr)
 	{
-		wprintf(L"ERROR: %s\n\n", strErr);
+		wprintf(L"ERROR: " WIDE_STR_FORMAT L"\n\n", strErr);
 	}
 	wprintf(L"USAGE: vttcompile [options] <in.ttf> [out.ttf] \n");
 	wprintf(L"\t-a compile everything \n");
@@ -650,7 +650,7 @@ int main(int argc, char* argv[])
 	{
 		fwprintf(stderr, errMsg);
 		fwprintf(stderr, L"\n");
-		fwprintf(stderr, L"Can not open font file %hs!\n", inFile.c_str());
+		fwprintf(stderr, L"Can not open font file " NARROW_STR_FORMAT L"!\n", inFile.c_str());
 		exit(EXIT_FAILURE);
 	}
 


### PR DESCRIPTION
The test case in issue 20 uncovers 3 problems:

- Microsoft compiler treats %s passed to *w*printf(), different from everybody else. So we need to special-case Microsoft compiler with one wide-string-format specifier, and everybody else with a different one. (and vice versa for narrow string - but there is only one case, in main()).

- After fixing the truncation, I found a missing null termination problem with the previous work-around for unix systems lacking a wctime() function (and need to call ctime() then convert from narrow to wide).

- and a similar problem with earlier long to int32_t, needs to replace a lot of %li by %i to not implicit convert to 64-bit long.

I only replaced %li in TTEngine.cpp ; the other seems to affect user messages (if error) and not critical.