### PR TITLE
Changes "illegal" to "invalid", "legal" to "valid", and preserving ca…

### DIFF
--- a/doc/VTT Language Reference/vttlang.html
+++ b/doc/VTT Language Reference/vttlang.html
@@ -1860,7 +1860,7 @@
 			<ul>
 				<li>Not using an end parenthesis</li>
 				<li>Not closing a comment</li>
-				<li>Illegal characters within a number</li>
+				<li>Invalid characters within a number</li>
 			</ul>
 
 			<p>The compiler also reports errors regarding misused or missing <span class="hint-caps">CVT</span> numbers. For example, the compiler will report an error if a <span class="hint-caps">CVT</span> number is referenced that does not exist in the Control Value Table.</p>

--- a/src/CvtManager.cpp
+++ b/src/CvtManager.cpp
@@ -298,7 +298,7 @@ bool Attribute::SearchByValue(Attribute *tree, Symbol subAttribute, int32_t valu
 
 bool Attribute::SortByValue(Attribute **to, Attribute *from, wchar_t errMsg[]) {
 //	alternatively, to be a tad more memory efficient, could traverse source tree in prefix, inserting allocated nodes at the end of each visit,
-//	making sure to have two legal trees at any intermediate stage, for the purpose of standard de-allocation in case of any error.
+//	making sure to have two valid trees at any intermediate stage, for the purpose of standard de-allocation in case of any error.
 	if (from) {
 		if (!Attribute::SortByValue(to,from->left,errMsg)) return false;
 		if (!Attribute::SortByValue(to,from->right,errMsg)) return false;
@@ -419,7 +419,7 @@ public:
 	virtual bool GetAttributeStrings(int32_t cvtNum, wchar_t charGroup[], wchar_t linkColor[], wchar_t linkDirection[], wchar_t cvtCategory[], wchar_t relative[]);
 	virtual bool GetCharGroupString(CharGroup group, wchar_t string[]);
 	virtual bool GetSpacingText(CharGroup group, wchar_t spacingText[]);
-	virtual int32_t GetBestCvtMatch(CharGroup charGroup, LinkColor linkColor, LinkDirection linkDirection, CvtCategory cvtCategory, int32_t distance); // returns illegalCvtNum if no match
+	virtual int32_t GetBestCvtMatch(CharGroup charGroup, LinkColor linkColor, LinkDirection linkDirection, CvtCategory cvtCategory, int32_t distance); // returns invalidCvtNum if no match
 	virtual void PutCvtBinary(int32_t size, unsigned char data[]);
 	virtual void GetCvtBinary(int32_t *size, unsigned char data[]);
 	virtual int32_t GetCvtBinarySize(void);
@@ -473,7 +473,7 @@ ControlValue *NewCvtData(void) {
 		cvt->value = 0;
 		cvt->attribute = 0;
 		cvt->breakPpemSize = 0;
-		cvt->parent = illegalCvtNum;
+		cvt->parent = invalidCvtNum;
 	//	cvt->delta = NULL;
 	}
 	return cvtData;
@@ -692,7 +692,7 @@ bool Scanner::GetSym(void) {
 			case L'~' : this->GetCh(); this->sym = relatesTo; break;
 		//	case L'\r': this->GetCh(); this->sym = eol; break;
 			case L'\0': this->sym = eot; break;
-			default  : this->GetCh(); swprintf(this->errMsg,L"Illegal character in control value table"); return false; break;
+			default  : this->GetCh(); swprintf(this->errMsg,L"Invalid character in control value table"); return false; break;
 		}
 	}
 	return true;
@@ -1053,7 +1053,7 @@ bool PrivateControlValueTable::Parameter(ActParam *actParam) {
 		actParam->type = anyS; actParam->literal = this->scanner.literal;
 		if (!this->scanner.GetSym()) return false;
 	} else {
-		swprintf(this->errMsg,L"parameter starts with illegal symbol (+, -, @, number, or \x22string\x22 expected)"); return false;
+		swprintf(this->errMsg,L"parameter starts with invalid symbol (+, -, @, number, or \x22string\x22 expected)"); return false;
 	}
 	return true; // by now
 } // PrivateControlValueTable::Parameter
@@ -1143,7 +1143,7 @@ bool PrivateControlValueTable::Factor(ActParam *actParam) {
 		if (this->scanner.sym != rightParen) { swprintf(this->errMsg,L") expected"); return false; }
 		if (!this->scanner.GetSym()) return false;
 	} else {
-		swprintf(this->errMsg,L"factor starts with illegal symbol (number or ( expected)"); return false;
+		swprintf(this->errMsg,L"factor starts with invalid symbol (number or ( expected)"); return false;
 	}
 	return true; // by now
 } // PrivateControlValueTable::Factor
@@ -1163,8 +1163,8 @@ bool PrivateControlValueTable::PixelAtPpemRange(DeltaColor cmdColor, ActParam *a
 	if (this->scanner.sym == percent) { // optional delta color sub-parameter
 		this->scanner.GetSym();
 		this->Parameter(&colorParam);
-		if (colorParam.type != naturalN || DeltaColorOfByte((unsigned char)(colorParam.value/one6)) == illegalDelta) {
-			swprintf(this->errMsg,L"illegal delta color flag (can be " NARROW_STR_FORMAT L" only)",AllDeltaColorBytes());
+		if (colorParam.type != naturalN || DeltaColorOfByte((unsigned char)(colorParam.value/one6)) == invalidDelta) {
+			swprintf(this->errMsg,L"invalid delta color flag (can be " NARROW_STR_FORMAT L" only)",AllDeltaColorBytes());
 			this->scanner.ErrUnGetSym(); return false;
 		}
 		actParam->deltaColor = DeltaColorOfByte((unsigned char)(colorParam.value/one6));
@@ -1402,7 +1402,7 @@ int32_t PrivateControlValueTable::HighestCvtIdx(void) {
 
 int32_t PrivateControlValueTable::CvtNumOf(int32_t idx) {
 	this->AssertSortedCvt();
-	return this->cvtDataSorted && this->lowestCvtIdx <= idx && idx <= this->highestCvtIdx ? this->cvtKeyOfIdx[idx].num : illegalCvtNum;
+	return this->cvtDataSorted && this->lowestCvtIdx <= idx && idx <= this->highestCvtIdx ? this->cvtKeyOfIdx[idx].num : invalidCvtNum;
 } // PrivateControlValueTable::CvtNumOf
 
 int32_t PrivateControlValueTable::CvtIdxOf(int32_t num) {
@@ -1469,7 +1469,7 @@ int32_t PrivateControlValueTable::GetBestCvtMatch(CharGroup charGroup, LinkColor
 	uint32_t lowAttr,highAttr,lowValue,highValue,catMask4cvtDummy;
 	CvtKey cvtKey,targetKey;
 
-	if (!this->cvtDataValid || cvtCategory == cvtAnyCategory) return illegalCvtNum;
+	if (!this->cvtDataValid || cvtCategory == cvtAnyCategory) return invalidCvtNum;
 	
 	if (cvtCategory == -1) {
 		catMask4cvtDummy = ~subAttributeMask; // since cvtCategory occupies lowest 8 bits...
@@ -1512,7 +1512,7 @@ int32_t PrivateControlValueTable::GetBestCvtMatch(CharGroup charGroup, LinkColor
 		else if (highAttr == targetKey.attribute) return highCvtNum;
 	//	else there is no cvt in this linkDirection and cvtCategory
 	}
-	return illegalCvtNum; // by now
+	return invalidCvtNum; // by now
 } // PrivateControlValueTable::GetBestCvtMatch
 
 void PrivateControlValueTable::PutCvtBinary(int32_t size, unsigned char data[]) {
@@ -1578,7 +1578,7 @@ void PrivateControlValueTable::AssertSortedCvt(void) {
 	cvtIdx = 0;
 	this->cvtKeyOfIdx[cvtIdx].attribute = 0;
 	this->cvtKeyOfIdx[cvtIdx].value		= 0; // low sentinel
-	this->cvtKeyOfIdx[cvtIdx].num		= illegalCvtNum; // cvtNum irrelevant, just silence BC
+	this->cvtKeyOfIdx[cvtIdx].num		= invalidCvtNum; // cvtNum irrelevant, just silence BC
 	cvtIdx++;
 	for (cvtNum = 0; cvtNum <= this->highestCvtNum; cvtNum++) {
 		cvt = &this->cpgmData[cvtNum];
@@ -1599,12 +1599,12 @@ void PrivateControlValueTable::AssertSortedCvt(void) {
 	}
 	this->cvtKeyOfIdx[cvtIdx].attribute = 0xffffffff;
 	this->cvtKeyOfIdx[cvtIdx].value		= 0xffff; // high sentinel
-	this->cvtKeyOfIdx[cvtIdx].num		= illegalCvtNum; // cvtNum irrelevant, just silence BC
+	this->cvtKeyOfIdx[cvtIdx].num		= invalidCvtNum; // cvtNum irrelevant, just silence BC
 	cvtIdx++;
 	this->lowestCvtIdx = 1;
 	this->highestCvtIdx = cvtIdx-2;
 	this->SortCvtKeys(0,cvtIdx-1);
-	for (cvtNum = this->lowestCvtNum; cvtNum <= this->highestCvtNum; cvtNum++) this->cvtIdxOfNum[cvtNum] = illegalCvtNum; // init possibly sparsely populated cvt
+	for (cvtNum = this->lowestCvtNum; cvtNum <= this->highestCvtNum; cvtNum++) this->cvtIdxOfNum[cvtNum] = invalidCvtNum; // init possibly sparsely populated cvt
 	for (cvtIdx = this->lowestCvtIdx; cvtIdx <= this->highestCvtIdx; cvtIdx++) this->cvtIdxOfNum[this->cvtKeyOfIdx[cvtIdx].num] = (short)cvtIdx; // setup bijectivity
 	this->cvtDataSorted = true;
 } // PrivateControlValueTable::AssertSortedCvt

--- a/src/CvtManager.h
+++ b/src/CvtManager.h
@@ -34,7 +34,7 @@ typedef enum {cvtAnyCategory = 0, cvtDistance, cvtStroke, cvtRound,
 
 #define	maxCvtNum 0x1000L // get past FontLab's Else
 
-#define illegalCvtNum (-1)
+#define invalidCvtNum (-1)
 
 #define cvtAttributeStrgLen 64
 
@@ -59,7 +59,7 @@ public:
 	virtual int32_t NumCharGroups(void) = 0;
 	virtual bool GetCharGroupString(CharGroup charGroup, wchar_t string[]) = 0;
 	virtual bool GetSpacingText(CharGroup charGroup, wchar_t spacingText[]) = 0;
-	virtual int32_t GetBestCvtMatch(CharGroup charGroup, LinkColor linkColor, LinkDirection linkDirection, CvtCategory cvtCategory, int32_t distance) = 0; // returns illegalCvtNum if no match
+	virtual int32_t GetBestCvtMatch(CharGroup charGroup, LinkColor linkColor, LinkDirection linkDirection, CvtCategory cvtCategory, int32_t distance) = 0; // returns invalidCvtNum if no match
 	virtual void PutCvtBinary(int32_t size, unsigned char data[]) = 0;
 	virtual void GetCvtBinary(int32_t *size, unsigned char data[]) = 0;
 	virtual int32_t GetCvtBinarySize(void) = 0;

--- a/src/GUIDecorations.h
+++ b/src/GUIDecorations.h
@@ -66,11 +66,11 @@ typedef enum {alwaysDelta = 0,
 			  ctNatVerRGBFAWYAADelta, ctComVerRGBFAWYAADelta, ctNatHorRGBFAWYAADelta, ctComHorRGBFAWYAADelta,
 			  ctNatVerBGRFAWYAADelta, ctComVerBGRFAWYAADelta, ctNatHorBGRFAWYAADelta, ctComHorBGRFAWYAADelta,
 			  // see also PixelValuePanel::DrawColPict
-			  illegalDelta } DeltaColor;
+			  invalidDelta } DeltaColor;
 #define firstDeltaColor alwaysDelta
 #define firstCTDeltaColor ctNatVerRGBIAWBLYDelta
 #define lastCTDeltaColor ctComHorBGRFAWYAADelta
-#define lastDeltaColor illegalDelta
+#define lastDeltaColor invalidDelta
 #define numDeltaColors (lastDeltaColor - firstDeltaColor + 1)
 
 #define maxRoundArrowHeads 9

--- a/src/TMTParser.cpp
+++ b/src/TMTParser.cpp
@@ -19,7 +19,7 @@
 #include "TTGenerator.h"
 #include "TMTParser.h"
 
-#define idents 		illegal
+#define idents 		invalid
 #define compLogics	2L
 #define phases		4L
 #define serifs		5L
@@ -38,9 +38,9 @@
 #define TermComment(self) (self->ch == L'*' && self->ch2 == L'/')
 #define	Numeric(ch) (L'0' <= (ch) && (ch) <= L'9')
 #define Alpha(ch) ((L'A' <= (ch) && (ch) <= L'Z') || (L'a' <= (ch) && (ch) <= L'z'))
-#define Command(self) (align <= (self)->sym && (self)->sym <= illegal)
+#define Command(self) (align <= (self)->sym && (self)->sym <= invalid)
 #define InitFlag(self) (leftDir <= (self)->sym && (self)->sym <= postRound)
-#define InitParam(self) (illegal <= (self)->sym && (self)->sym <= leftDir) // leftDir included because it doubles up as lessThan in the minDistGeneral parameter
+#define InitParam(self) (invalid <= (self)->sym && (self)->sym <= leftDir) // leftDir included because it doubles up as lessThan in the minDistGeneral parameter
 #define Separator(self) (period <= (self)->sym && (self)->sym <= semiColon)
 #define InterpolateCmd(cmd) ((cmd) == xInterpolate || (cmd) == xInterpolate0 || (cmd) == xInterpolate1 || (cmd) == xIPAnchor || (cmd) == yInterpolate || (cmd) == yInterpolate0 || (cmd) == yInterpolate1 || (cmd) == yIPAnchor)
 #define maxGenerators 3
@@ -69,10 +69,10 @@ typedef enum { align = 0, asM, autoHinter,
 			   xAlign, xAnchor, xBDelta, xCDelta, xDelta, xDiagonal, xDist, xDoubleGrid, xDownToGrid, xGDelta, xHalfGrid, xInterpolate, xInterpolate0, xInterpolate1, xIPAnchor, xLink, xMove, xNoRound, xRound, xShift, xSmooth, xStem, xStroke, xUpToGrid, // MODIFY GREGH
 			   //yAlign, yAnchor, yBDelta, yDelta, yDiagonal, yDist, yDoubleGrid, yDownToGrid, yGDelta, yHalfGrid, yInterpolate, yInterpolate0, yInterpolate1, yIPAnchor, yLink, yMove, yNoRound, yRound, yShift, ySmooth, yStem, yStroke, yUpToGrid,
 			   yAlign, yAnchor, yBDelta, yCDelta, yDelta, yDiagonal, yDist, yDoubleGrid, yDownToGrid, yGDelta, yHalfGrid, yInterpolate, yInterpolate0, yInterpolate1, yIPAnchor, yLink, yMove, yNoRound, yRound, yShift, ySmooth, yStem, yStroke, yUpToGrid, // MODIFY GREGH
-			   illegal,
+			   invalid,
 			   leftParen, plus, minus, natural, rational, literal, aT, atLeast,
 			   upDir, // COM
-			   leftDir, /* InitParam (including above illegal) */
+			   leftDir, /* InitParam (including above invalid) */
 			   rightDir, italAngle, adjItalAngle, 
 			   optStroke, optStrokeLeftBias, optStrokeRightBias, // COM
 			   postRound, /* leftDir through postRound: Flags() */
@@ -384,7 +384,7 @@ void TMTSourceParser::Parse(bool *changedSrc, int32_t *errPos, int32_t *errLen, 
 	while (this->errPos < 0 && Command(this)) {
 		cmdStart = this->prevPos;
 		cmd = this->sym;
-		if (cmd == illegal) this->ErrorMsg(syntactical,L"unknown VTT Talk command");
+		if (cmd == invalid) this->ErrorMsg(syntactical,L"unknown VTT Talk command");
 		if (cmd == xAnchor || cmd == xInterpolate || cmd == xIPAnchor || cmd == xLink ||
 			cmd == yAnchor || cmd == yInterpolate || cmd == yIPAnchor || cmd == yLink) this->XFormToNewSyntax();
 		this->GetSym();
@@ -582,20 +582,20 @@ bool TMTSourceParser::MakeProjFreeVector(bool haveFlag, int32_t flagValue, bool 
 	bool pvOverrideError = false,fvOverrideError = false;
 
 	projFreeVector->pv.dir = flagToDir[idx%numTTVDirections];
-	projFreeVector->pv.from = projFreeVector->pv.to = illegalKnotNum;
+	projFreeVector->pv.from = projFreeVector->pv.to = invalidKnotNum;
 	for (i = 0; i < children; i++) projFreeVector->fv[i] = projFreeVector->pv;
 	if (!this->legacyCompile)
 	{
 
 		if (parent != NULL && parent->hasTtvOverride) { // NULL for Anchors, they have no parents
 			projFreeVector->pv = parent->ttvOverride;
-			if (projFreeVector->pv.from == illegalKnotNum) projFreeVector->pv.from = (short) (parent->numValue / one6);
+			if (projFreeVector->pv.from == invalidKnotNum) projFreeVector->pv.from = (short) (parent->numValue / one6);
 			if (!y && haveFlag) pvOverrideError = true;
 		}
 		for (i = 0; i < children && !pvOverrideError && !fvOverrideError; i++) {
 			if (child[i].hasTtvOverride) {
 				projFreeVector->fv[i] = child[i].ttvOverride;
-				if (projFreeVector->fv[i].from == illegalKnotNum) projFreeVector->fv[i].from = (short) (child[i].numValue / one6);
+				if (projFreeVector->fv[i].from == invalidKnotNum) projFreeVector->fv[i].from = (short) (child[i].numValue / one6);
 				if (y && haveFlag) fvOverrideError = true;
 			}
 		}
@@ -638,7 +638,7 @@ void TMTSourceParser::Dispatch(Symbol cmd, short params, ActParam param[], wchar
 		}
 		case dStroke: {
 			bool leftStationary[2];
-			short cvt = (short)((params <= 6) ? illegalCvtNum : param[6].numValue/one6);
+			short cvt = (short)((params <= 6) ? invalidCvtNum : param[6].numValue/one6);
 			short actualCvt;
 			short knot[4];
 			wchar_t buf[32];
@@ -668,7 +668,7 @@ void TMTSourceParser::Dispatch(Symbol cmd, short params, ActParam param[], wchar
 		case iStroke: {
 			bool leftStationary[2];
 			short knot[4],height[2],phase,actualCvt;
-			short cvt = (short)((params <= 9) ? illegalCvtNum : param[9].numValue/one6);
+			short cvt = (short)((params <= 9) ? invalidCvtNum : param[9].numValue/one6);
 			wchar_t buf[32];
 			
 			for (i = 0; i < 2; i++) leftStationary[i] = param[i].numValue > 0;
@@ -731,7 +731,7 @@ void TMTSourceParser::Dispatch(Symbol cmd, short params, ActParam param[], wchar
 		case yStroke: {
 			bool leftStationary[2],nearVert,nearHorz;
 			short base = cmd != xStroke && cmd != yStroke ? 2 : 0,optionalBase = base + 4, knot[4];
-			short cvt = (short)((params <= optionalBase || param[optionalBase].type == ppemSize) ? illegalCvtNum : param[optionalBase].numValue/one6);
+			short cvt = (short)((params <= optionalBase || param[optionalBase].type == ppemSize) ? invalidCvtNum : param[optionalBase].numValue/one6);
 			short ppem = (short)((params <= optionalBase || param[params-1].type != ppemSize) ? -1 : param[params-1].numValue/one6);
 			FVOverride fvOverride = cmd == stroke ? fvOldMethod : (cmd == xDiagonal || cmd == xStroke ? fvForceX : (cmd == yDiagonal || cmd == yStroke ? fvForceY : fvStandard));
 			short actualCvt;
@@ -768,7 +768,7 @@ void TMTSourceParser::Dispatch(Symbol cmd, short params, ActParam param[], wchar
 		case yRound: {
 			short knot[2],cvt;
 			
-			cvt = params > 2 ? (short)param[2].numValue/one6 : illegalCvtNum;
+			cvt = params > 2 ? (short)param[2].numValue/one6 : invalidCvtNum;
 			for (i = 0; i < 2; i++) knot[i] = (short)(param[i].numValue/one6);
 			
 			this->RegisterPartner(knot[0],knot[1],cmd == yStem || cmd == yRound,cmd == xRound || cmd == yRound,cvt);
@@ -794,9 +794,9 @@ void TMTSourceParser::Dispatch(Symbol cmd, short params, ActParam param[], wchar
 			bool y = cmd == yAnchor,haveFlag = param[0].type == angleFlag;
 			ActParam *knotParam = &param[haveFlag];
 			short knot = (short)(knotParam->numValue/one6);
-			short cvt = (short)((params <= haveFlag + 1) ? illegalCvtNum : param[haveFlag + 1].numValue/one6);
+			short cvt = (short)((params <= haveFlag + 1) ? invalidCvtNum : param[haveFlag + 1].numValue/one6);
 			Height *height = y ? this->TheHeight(knot) : NULL;
-			short cvtHint = height ? height->cvtOverride : illegalCvtNum;
+			short cvtHint = height ? height->cvtOverride : invalidCvtNum;
 			ProjFreeVector projFreeVector;
 			
 			if (cvt >= 0 && cvtHint >= 0)
@@ -827,13 +827,13 @@ void TMTSourceParser::Dispatch(Symbol cmd, short params, ActParam param[], wchar
 			ActParam *parentParam = &param[haveFlag+havePostRound],*childParam = &param[haveFlag+havePostRound+1];
 			short parent = (short)(parentParam->numValue/one6),
 				  child = (short)(childParam->numValue/one6),
-				  cvt = haveCvt ? (short)(param[base].numValue/one6) : illegalCvtNum,actualCvt = cvt,
+				  cvt = haveCvt ? (short)(param[base].numValue/one6) : invalidCvtNum,actualCvt = cvt,
 				  minDists = haveMinDist ? param[base+haveCvt].minDists : -1,
 				  jumpPpemSize[maxMinDist];
 			int32_t *jSize = minDists >= 0 ? &param[base+haveCvt].jumpPpemSize[0] : NULL;
 			Partner *partner = this->ThePartner(y,parent,child);
 			CvtCategory cvtCategory = dist ? cvtAnyCategory : (partner ? partner->category : cvtDistance);
-			short cvtHint = partner ? partner->cvtOverride : illegalCvtNum;
+			short cvtHint = partner ? partner->cvtOverride : invalidCvtNum;
 			short lsb = this->knots - PHANTOMPOINTS,rsb = lsb + 1;
 			CharGroup charGroup;
 			LinkColor linkColor;
@@ -997,7 +997,7 @@ void TMTSourceParser::Dispatch(Symbol cmd, short params, ActParam param[], wchar
 				bool haveCvt = params > optParamOffs && param[optParamOffs].type == cvtN;
 				ActParam *childParam = &param[haveFlag];
 				short child = (short)(childParam->numValue/one6),
-					  cvt = haveCvt ? (short)(param[optParamOffs].numValue/one6) : illegalCvtNum;
+					  cvt = haveCvt ? (short)(param[optParamOffs].numValue/one6) : invalidCvtNum;
 				ProjFreeVector projFreeVector;
 
 				if (this->MakeProjFreeVector(haveFlag,param[0].numValue,y,NULL,childParam,1,&projFreeVector,errMsg)) {
@@ -1041,7 +1041,7 @@ void TMTSourceParser::Dispatch(Symbol cmd, short params, ActParam param[], wchar
 				ActParam *parentParam = &param[haveFlag],*childParam = &param[haveFlag+1];
 				short parent = (short)(parentParam->numValue/one6),
 					  child = (short)(childParam->numValue/one6),
-					  cvt = haveCvt ? (short)(param[optParamOffs].numValue/one6) : illegalCvtNum;
+					  cvt = haveCvt ? (short)(param[optParamOffs].numValue/one6) : invalidCvtNum;
 				ProjFreeVector projFreeVector;
 
 				if (this->MakeProjFreeVector(haveFlag,param[0].numValue,y,parentParam,childParam,1,&projFreeVector,errMsg)) {
@@ -1070,7 +1070,7 @@ void TMTSourceParser::Dispatch(Symbol cmd, short params, ActParam param[], wchar
 					  grandParent0 = (short)(grandParent0Param->numValue/one6),
 					  parent       = (short)(parentParam->numValue/one6),
 					  child        = (short)(childParam->numValue/one6),
-					  cvt  = !dist ? (short)(cvtParam->numValue/one6) : illegalCvtNum,
+					  cvt  = !dist ? (short)(cvtParam->numValue/one6) : invalidCvtNum,
 					  grandParent1 = (short)(grandParent1Param->numValue/one6);
 				ProjFreeVector projFreeVector;
 
@@ -1105,10 +1105,10 @@ void TMTSourceParser::Dispatch(Symbol cmd, short params, ActParam param[], wchar
 					  grandParent0 = (short)(grandParent0Param->numValue/one6),
 					  parent0      = (short)(parent0Param->numValue/one6),
 					  child0       = (short)(child0Param->numValue/one6),
-					  cvt0 = !dist ? (short)(cvt0Param->numValue/one6) : illegalCvtNum,
+					  cvt0 = !dist ? (short)(cvt0Param->numValue/one6) : invalidCvtNum,
 					  parent1      = (short)(parent1Param->numValue/one6),
 					  child1       = (short)(child1Param->numValue/one6),
-					  cvt1 = !dist ? (short)(cvt1Param->numValue/one6) : illegalCvtNum,
+					  cvt1 = !dist ? (short)(cvt1Param->numValue/one6) : invalidCvtNum,
 					  grandParent1 = (short)(grandParent1Param->numValue/one6);
 				ProjFreeVector projFreeVector;
 
@@ -1143,10 +1143,10 @@ void TMTSourceParser::Dispatch(Symbol cmd, short params, ActParam param[], wchar
 					  grandParent0 = (short)(grandParent0Param->numValue/one6),
 					  parent0      = (short)(parent0Param->numValue/one6),
 					  child0       = (short)(child0Param->numValue/one6),
-					  cvt0 = !dist ? (short)(cvt0Param->numValue/one6) : illegalCvtNum,
+					  cvt0 = !dist ? (short)(cvt0Param->numValue/one6) : invalidCvtNum,
 					  parent1      = (short)(parent1Param->numValue/one6),
 					  child1       = (short)(child1Param->numValue/one6),
-					  cvt1 = !dist ? (short)(cvt1Param->numValue/one6) : illegalCvtNum,
+					  cvt1 = !dist ? (short)(cvt1Param->numValue/one6) : invalidCvtNum,
 					  grandParent1 = (short)(grandParent1Param->numValue/one6);
 				ProjFreeVector projFreeVector0,projFreeVector1;
 
@@ -1176,7 +1176,7 @@ void TMTSourceParser::Dispatch(Symbol cmd, short params, ActParam param[], wchar
 				ActParam *parent0Param = &param[0],*child0Param = &param[1],*parent1Param = &param[2+haveCvt0],*child1Param = &param[3+haveCvt0];
 				short parent0 = (short)(parent0Param->numValue/one6),
 					  child0 = (short)(child0Param->numValue/one6),
-					  cvt0 = haveCvt0 ? (short)(param[cvtParamOffs0].numValue/one6) : illegalCvtNum,
+					  cvt0 = haveCvt0 ? (short)(param[cvtParamOffs0].numValue/one6) : invalidCvtNum,
 					  parent1 = (short)(parent1Param->numValue/one6),
 					  child1 = (short)(child1Param->numValue/one6),
 					  cvt1 = haveCvt1 ? (short)(param[cvtParamOffs1].numValue/one6) : cvt0;
@@ -1208,7 +1208,7 @@ void TMTSourceParser::Dispatch(Symbol cmd, short params, ActParam param[], wchar
 				short grandParent0 = (short)(grandParent0Param->numValue/one6),
 					  parent0 = (short)(parent0Param->numValue/one6),
 					  child0 = (short)(child0Param->numValue/one6),
-					  cvt0 = haveCvt0 ? (short)(param[cvtParamOffs0].numValue/one6) : illegalCvtNum,
+					  cvt0 = haveCvt0 ? (short)(param[cvtParamOffs0].numValue/one6) : invalidCvtNum,
 					  parent1 = (short)(parent1Param->numValue/one6),
 					  child1 = (short)(child1Param->numValue/one6),
 					  grandParent1 = (short)(grandParent1Param->numValue/one6),
@@ -1426,7 +1426,7 @@ void TMTSourceParser::Flag(ActParam *actParam) {
 				actParam->fvPoint0 = (short)(fvPoint0.numValue/one6);
 				actParam->fvPoint1 = (short)(fvPoint1.numValue/one6);
 			} else {
-				actParam->fvPoint0 = actParam->fvPoint1 = illegalKnotNum;
+				actParam->fvPoint0 = actParam->fvPoint1 = invalidKnotNum;
 			}
 #endif
 			break;
@@ -1454,8 +1454,8 @@ void TMTSourceParser::Parameter(ActParam *actParam) {
 		this->prevPrevPos = paramStart; // can't recursively call this->Parameter() here...
 		actParam->hasTtvOverride = false;
 		actParam->ttvOverride.dir  = xRomanDir; // say
-		actParam->ttvOverride.from = illegalKnotNum;
-		actParam->ttvOverride.to   = illegalKnotNum;
+		actParam->ttvOverride.from = invalidKnotNum;
+		actParam->ttvOverride.to   = invalidKnotNum;
 
 		if (this->sym == aT) {
 			subParams = 0;
@@ -1476,7 +1476,7 @@ void TMTSourceParser::Parameter(ActParam *actParam) {
 				actParam->type = rangeOfPpemNcolorOpt; // by now
 			}
 		} else if (!this->legacyCompile && (this->sym == colon || this->sym == rightDir || this->sym == upDir)) {
-			// the following are all legal:
+			// the following are all valid:
 			//
 			// knot                   no ttv override
 			// knot >                 ttv in x-direction
@@ -1536,10 +1536,10 @@ void TMTSourceParser::Parameter(ActParam *actParam) {
 
 			if (gotKnot[0] && !gotKnot[1]) {
 				this->prevPrevPos = firstLocalParamStart;
-				this->ErrorMsg(contextual,L"illegal freedom or projection vector (second knot expected)");
+				this->ErrorMsg(contextual,L"invalid freedom or projection vector (second knot expected)");
 			} else if (gotKnot[0] && gotKnot[1] && actParam->ttvOverride.from == actParam->ttvOverride.to) {
 				this->prevPrevPos = firstLocalParamStart;
-				this->ErrorMsg(contextual,L"illegal freedom or projection vector (knots must differ)");
+				this->ErrorMsg(contextual,L"invalid freedom or projection vector (knots must differ)");
 			} 
 			
 			// no italic or adjusted italic angle yet			
@@ -1564,7 +1564,7 @@ void TMTSourceParser::Parameter(ActParam *actParam) {
 	} else if (this->sym == atLeast || this->sym == leftDir) {
 		this->MinDist(actParam);
 	} else {
-		this->ErrorMsg(syntactical,L"parameter starts with illegal symbol (+, -, @, <, >=, number, or \x22string\x22 expected)"); actParam->type = voidParam; actParam->numValue = 0;
+		this->ErrorMsg(syntactical,L"parameter starts with invalid symbol (+, -, @, <, >=, number, or \x22string\x22 expected)"); actParam->type = voidParam; actParam->numValue = 0;
 	}
 	this->prevPrevPos = paramStart;
 } /* TMTSourceParser::Parameter */
@@ -1643,7 +1643,7 @@ void TMTSourceParser::ValidateParameter(ActParam *actParam) {
 			int32_t knot = actParam->numValue/one6;
 			
 			if (knot < 0 || knot >= this->knots) {
-				swprintf(errMsg,L"illegal knot number (can be in range 0 through %hi only)",this->knots-1); this->ErrorMsg(contextual,errMsg);
+				swprintf(errMsg,L"invalid knot number (can be in range 0 through %hi only)",this->knots-1); this->ErrorMsg(contextual,errMsg);
 				actParam->numValue = 0;
 			}
 		//	for knotNttvOpt, ttvKnot[0], and ttvKnot[1] already validated against being in range
@@ -1656,7 +1656,7 @@ void TMTSourceParser::ValidateParameter(ActParam *actParam) {
 			int32_t cvt = actParam->numValue/one6;
 			
 			if (!this->font->TheCvt()->CvtNumExists(cvt)) {
-				this->ErrorMsg(contextual,L"illegal cvt number (must be defined in the control value table)");
+				this->ErrorMsg(contextual,L"invalid cvt number (must be defined in the control value table)");
 				actParam->numValue = 0;
 			}
 			break;
@@ -1667,25 +1667,25 @@ void TMTSourceParser::ValidateParameter(ActParam *actParam) {
 			break;
 		case phaseN:
 			if (actParam->numValue < 0 || actParam->numValue >= phases*one6) {
-				swprintf(errMsg,L"illegal phase type (can be in range 0 through %li only)",phases-1); this->ErrorMsg(contextual,errMsg);
+				swprintf(errMsg,L"invalid phase type (can be in range 0 through %li only)",phases-1); this->ErrorMsg(contextual,errMsg);
 				actParam->numValue = 0;
 			}
 			break;
 		case angle100N:
 			if (actParam->numValue < 0 || actParam->numValue > maxAngle*one6) {
-				swprintf(errMsg,L"illegal angle x100 (can be in range 0 through %li only)",maxAngle); this->ErrorMsg(contextual,errMsg);
+				swprintf(errMsg,L"invalid angle x100 (can be in range 0 through %li only)",maxAngle); this->ErrorMsg(contextual,errMsg);
 				actParam->numValue = 0;
 			}
 			break;
 		case colorN:
-			if (DeltaColorOfByte((unsigned char)(actParam->numValue/one6)) == illegalDelta) {
-				swprintf(errMsg,L"illegal delta color flag (can be " NARROW_STR_FORMAT L" only)",AllDeltaColorBytes()); this->ErrorMsg(contextual,errMsg);
+			if (DeltaColorOfByte((unsigned char)(actParam->numValue/one6)) == invalidDelta) {
+				swprintf(errMsg,L"invalid delta color flag (can be " NARROW_STR_FORMAT L" only)",AllDeltaColorBytes()); this->ErrorMsg(contextual,errMsg);
 				actParam->numValue = 0;
 			}
 			break;
 		case serifN:
 			if (actParam->numValue < 0 || actParam->numValue >= serifs*one6) {
-				swprintf(errMsg,L"illegal serif type (can be in range 0 through %li only)",serifs-1); this->ErrorMsg(contextual,errMsg);
+				swprintf(errMsg,L"invalid serif type (can be in range 0 through %li only)",serifs-1); this->ErrorMsg(contextual,errMsg);
 				actParam->numValue = 0;
 			}
 			break;
@@ -1696,7 +1696,7 @@ void TMTSourceParser::ValidateParameter(ActParam *actParam) {
 		case rationalN:
 		case posRationalN:
 			if ((actParam->type == posRationalN && actParam->numValue < 0) || actParam->numValue < -maxPixelValue || actParam->numValue > maxPixelValue) {
-				swprintf(errMsg,L"illegal pixel size (can be in range %li through %li only)",actParam->type == posRationalN ? 0 : -maxPixelValue/one6,maxPixelValue/one6); this->ErrorMsg(contextual,errMsg);
+				swprintf(errMsg,L"invalid pixel size (can be in range %li through %li only)",actParam->type == posRationalN ? 0 : -maxPixelValue/one6,maxPixelValue/one6); this->ErrorMsg(contextual,errMsg);
 				actParam->numValue = one6;
 			}
 			if (actParam->numValue == 0) {
@@ -1707,7 +1707,7 @@ void TMTSourceParser::ValidateParameter(ActParam *actParam) {
 		case ppemSize:
 		case ppemN:
 			if (actParam->numValue < one6 || actParam->numValue >= maxPpemSize*one6) {
-				swprintf(errMsg,L"illegal ppem number (can be in range 1 through %li only)",maxPpemSize-1); this->ErrorMsg(contextual,errMsg);
+				swprintf(errMsg,L"invalid ppem number (can be in range 1 through %li only)",maxPpemSize-1); this->ErrorMsg(contextual,errMsg);
 				actParam->numValue = one6;
 			}
 			break;
@@ -1793,7 +1793,7 @@ void TMTSourceParser::Factor (ActParam *actParam) {
 		this->Expression(actParam);
 		if (this->sym == rightParen) this->GetSym(); else this->ErrorMsg(syntactical,L") expected");
 	} else {
-		this->ErrorMsg(syntactical,L"factor starts with illegal symbol (number or ( expected)");
+		this->ErrorMsg(syntactical,L"factor starts with invalid symbol (number or ( expected)");
 		actParam->type = voidParam;
 	}
 } /* TMTSourceParser::Factor */
@@ -1945,7 +1945,7 @@ void TMTSourceParser::GetNumber(void) {
 			else
 				overflow = true;
 		} else
-			this->ErrorMsg(lexical,L"illegal character in number (can be digits 0 through 9 only)");
+			this->ErrorMsg(lexical,L"invalid character in number (can be digits 0 through 9 only)");
 		this->GetCh();
 	}
 	this->numValue *= one6;
@@ -1961,7 +1961,7 @@ void TMTSourceParser::GetNumber(void) {
 				} else
 					overflow = true;
 			} else
-				this->ErrorMsg(lexical,L"illegal character in number (can be digits 0 through 9 only)");
+				this->ErrorMsg(lexical,L"invalid character in number (can be digits 0 through 9 only)");
 			this->GetCh();
 		}
 		this->numValue += (decPlcs*one6 + pwrOf10/2)/pwrOf10;
@@ -1984,7 +1984,7 @@ Symbol Search(wchar_t *entry, short left, short right, short *matching) {
 		else if (diff < 0) left = mid + 1;
 		else return (Symbol)mid; // found
 	}
-	return illegal; // not found
+	return invalid; // not found
 } /* Search */
 
 void TMTSourceParser::GetIdent(void) {
@@ -1999,7 +1999,7 @@ void TMTSourceParser::GetIdent(void) {
 	}
 	id[i] = '\0';
 	this->sym = Search(id,0,idents-1,&matching);
-	if (this->sym != illegal) {
+	if (this->sym != invalid) {
 		replId = tmtCmd[this->sym].name;
 		replLen = (short)STRLENW(replId);
 		for (matching = 0; matching < replLen && id[matching] == replId[matching]; matching++);
@@ -2103,7 +2103,7 @@ void TMTSourceParser::GetSym(void) {
 					this->GetCh();
 					this->ReplAtCurrPos(2,L">|");
 				} else {
-					this->sym = illegal;
+					this->sym = invalid;
 				}
 				break;
 			case 0xAF:	this->sym = adjItalAngle; this->GetCh(); this->ReplAtCurrPos(1,L"//"); break; // replace Mac special char

--- a/src/TTAssembler.cpp
+++ b/src/TTAssembler.cpp
@@ -3398,10 +3398,10 @@ void TT_GetErrorString (short ErrorNb, wchar_t * ErrorString)
 			swprintf( ErrorString, L"DELTA with arguments in PUSHOFF mode");
 			break;
 		case tt_PUSHBWInPushON:
-			swprintf( ErrorString, L"Illegal use of PUSHB or PUSHW in PUSHON mode, use #PUSH instead");
+			swprintf( ErrorString, L"Invalid use of PUSHB or PUSHW in PUSHON mode, use #PUSH instead");
 			break;
 		case tt_WildCardInPush:
-			swprintf( ErrorString, L"Illegal use * in a PUSH instruction");
+			swprintf( ErrorString, L"Invalid use * in a PUSH instruction");
 			break;
 
 		case tt_NotImplemented:

--- a/src/TTEngine.cpp
+++ b/src/TTEngine.cpp
@@ -88,65 +88,65 @@ DeltaColor DeltaColorOfByte(unsigned char byte) {
 	static DeltaColor deltaColorOfByte[0xE0] = {
 		/*   0 */ blackDelta,
 		/*   1 */ greyDelta,
-		/*   2 */ ctNatVerRGBIAWBLYDelta, illegalDelta, illegalDelta, illegalDelta,
-		/*   6 */ ctComVerRGBIAWBLYDelta, illegalDelta, illegalDelta, illegalDelta,
-		/*  10 */ ctNatHorRGBIAWBLYDelta, illegalDelta, illegalDelta, illegalDelta,
-		/*  14 */ ctComHorRGBIAWBLYDelta, illegalDelta, illegalDelta, illegalDelta,
-		/*  18 */ ctNatVerBGRIAWBLYDelta, illegalDelta, illegalDelta, illegalDelta,
-		/*  22 */ ctComVerBGRIAWBLYDelta, illegalDelta, illegalDelta, illegalDelta,
-		/*  26 */ ctNatHorBGRIAWBLYDelta, illegalDelta, illegalDelta, illegalDelta,
-		/*  30 */ ctComHorBGRIAWBLYDelta, illegalDelta, illegalDelta, illegalDelta,
-				  illegalDelta, illegalDelta, illegalDelta, illegalDelta, 
-				  illegalDelta, illegalDelta, illegalDelta, illegalDelta, 
-				  illegalDelta, illegalDelta, illegalDelta, illegalDelta, 
-				  illegalDelta, illegalDelta, illegalDelta, illegalDelta, 
-				  illegalDelta, illegalDelta, illegalDelta, illegalDelta, 
-				  illegalDelta, illegalDelta, illegalDelta, illegalDelta, 
-				  illegalDelta, illegalDelta, illegalDelta, illegalDelta, 
-				  illegalDelta, illegalDelta, illegalDelta, illegalDelta, 
-		/*  66 */ ctNatVerRGBFAWBLYDelta, illegalDelta, illegalDelta, illegalDelta,
-		/*  70 */ ctComVerRGBFAWBLYDelta, illegalDelta, illegalDelta, illegalDelta,
-		/*  74 */ ctNatHorRGBFAWBLYDelta, illegalDelta, illegalDelta, illegalDelta,
-		/*  78 */ ctComHorRGBFAWBLYDelta, illegalDelta, illegalDelta, illegalDelta,
-		/*  82 */ ctNatVerBGRFAWBLYDelta, illegalDelta, illegalDelta, illegalDelta,
-		/*  86 */ ctComVerBGRFAWBLYDelta, illegalDelta, illegalDelta, illegalDelta,
-		/*  90 */ ctNatHorBGRFAWBLYDelta, illegalDelta, illegalDelta, illegalDelta,
-		/*  94 */ ctComHorBGRFAWBLYDelta, illegalDelta, illegalDelta, illegalDelta,
-				  illegalDelta, illegalDelta, illegalDelta, illegalDelta, 
-				  illegalDelta, illegalDelta, illegalDelta, illegalDelta, 
-				  illegalDelta, illegalDelta, illegalDelta, illegalDelta, 
-				  illegalDelta, illegalDelta, illegalDelta, illegalDelta, 
-				  illegalDelta, illegalDelta, illegalDelta, illegalDelta, 
-				  illegalDelta, illegalDelta, illegalDelta, illegalDelta, 
-				  illegalDelta, illegalDelta, illegalDelta, illegalDelta, 
-				  illegalDelta, illegalDelta, illegalDelta, illegalDelta, 
-		/* 130 */ ctNatVerRGBIAWYAADelta, illegalDelta, illegalDelta, illegalDelta,
-		/* 134 */ ctComVerRGBIAWYAADelta, illegalDelta, illegalDelta, illegalDelta,
-		/* 138 */ ctNatHorRGBIAWYAADelta, illegalDelta, illegalDelta, illegalDelta,
-		/* 142 */ ctComHorRGBIAWYAADelta, illegalDelta, illegalDelta, illegalDelta,
-		/* 146 */ ctNatVerBGRIAWYAADelta, illegalDelta, illegalDelta, illegalDelta,
-		/* 150 */ ctComVerBGRIAWYAADelta, illegalDelta, illegalDelta, illegalDelta,
-		/* 154 */ ctNatHorBGRIAWYAADelta, illegalDelta, illegalDelta, illegalDelta,
-		/* 158 */ ctComHorBGRIAWYAADelta, illegalDelta, illegalDelta, illegalDelta,
-				  illegalDelta, illegalDelta, illegalDelta, illegalDelta, 
-				  illegalDelta, illegalDelta, illegalDelta, illegalDelta, 
-				  illegalDelta, illegalDelta, illegalDelta, illegalDelta, 
-				  illegalDelta, illegalDelta, illegalDelta, illegalDelta, 
-				  illegalDelta, illegalDelta, illegalDelta, illegalDelta, 
-				  illegalDelta, illegalDelta, illegalDelta, illegalDelta, 
-				  illegalDelta, illegalDelta, illegalDelta, illegalDelta, 
-				  illegalDelta, illegalDelta, illegalDelta, illegalDelta, 
-		/* 194 */ ctNatVerRGBFAWYAADelta, illegalDelta, illegalDelta, illegalDelta,
-		/* 198 */ ctComVerRGBFAWYAADelta, illegalDelta, illegalDelta, illegalDelta,
-		/* 202 */ ctNatHorRGBFAWYAADelta, illegalDelta, illegalDelta, illegalDelta,
-		/* 206 */ ctComHorRGBFAWYAADelta, illegalDelta, illegalDelta, illegalDelta,
-		/* 210 */ ctNatVerBGRFAWYAADelta, illegalDelta, illegalDelta, illegalDelta,
-		/* 214 */ ctComVerBGRFAWYAADelta, illegalDelta, illegalDelta, illegalDelta,
-		/* 218 */ ctNatHorBGRFAWYAADelta, illegalDelta, illegalDelta, illegalDelta,
-		/* 222 */ ctComHorBGRFAWYAADelta, illegalDelta
+		/*   2 */ ctNatVerRGBIAWBLYDelta, invalidDelta, invalidDelta, invalidDelta,
+		/*   6 */ ctComVerRGBIAWBLYDelta, invalidDelta, invalidDelta, invalidDelta,
+		/*  10 */ ctNatHorRGBIAWBLYDelta, invalidDelta, invalidDelta, invalidDelta,
+		/*  14 */ ctComHorRGBIAWBLYDelta, invalidDelta, invalidDelta, invalidDelta,
+		/*  18 */ ctNatVerBGRIAWBLYDelta, invalidDelta, invalidDelta, invalidDelta,
+		/*  22 */ ctComVerBGRIAWBLYDelta, invalidDelta, invalidDelta, invalidDelta,
+		/*  26 */ ctNatHorBGRIAWBLYDelta, invalidDelta, invalidDelta, invalidDelta,
+		/*  30 */ ctComHorBGRIAWBLYDelta, invalidDelta, invalidDelta, invalidDelta,
+				  invalidDelta, invalidDelta, invalidDelta, invalidDelta, 
+				  invalidDelta, invalidDelta, invalidDelta, invalidDelta, 
+				  invalidDelta, invalidDelta, invalidDelta, invalidDelta, 
+				  invalidDelta, invalidDelta, invalidDelta, invalidDelta, 
+				  invalidDelta, invalidDelta, invalidDelta, invalidDelta, 
+				  invalidDelta, invalidDelta, invalidDelta, invalidDelta, 
+				  invalidDelta, invalidDelta, invalidDelta, invalidDelta, 
+				  invalidDelta, invalidDelta, invalidDelta, invalidDelta, 
+		/*  66 */ ctNatVerRGBFAWBLYDelta, invalidDelta, invalidDelta, invalidDelta,
+		/*  70 */ ctComVerRGBFAWBLYDelta, invalidDelta, invalidDelta, invalidDelta,
+		/*  74 */ ctNatHorRGBFAWBLYDelta, invalidDelta, invalidDelta, invalidDelta,
+		/*  78 */ ctComHorRGBFAWBLYDelta, invalidDelta, invalidDelta, invalidDelta,
+		/*  82 */ ctNatVerBGRFAWBLYDelta, invalidDelta, invalidDelta, invalidDelta,
+		/*  86 */ ctComVerBGRFAWBLYDelta, invalidDelta, invalidDelta, invalidDelta,
+		/*  90 */ ctNatHorBGRFAWBLYDelta, invalidDelta, invalidDelta, invalidDelta,
+		/*  94 */ ctComHorBGRFAWBLYDelta, invalidDelta, invalidDelta, invalidDelta,
+				  invalidDelta, invalidDelta, invalidDelta, invalidDelta, 
+				  invalidDelta, invalidDelta, invalidDelta, invalidDelta, 
+				  invalidDelta, invalidDelta, invalidDelta, invalidDelta, 
+				  invalidDelta, invalidDelta, invalidDelta, invalidDelta, 
+				  invalidDelta, invalidDelta, invalidDelta, invalidDelta, 
+				  invalidDelta, invalidDelta, invalidDelta, invalidDelta, 
+				  invalidDelta, invalidDelta, invalidDelta, invalidDelta, 
+				  invalidDelta, invalidDelta, invalidDelta, invalidDelta, 
+		/* 130 */ ctNatVerRGBIAWYAADelta, invalidDelta, invalidDelta, invalidDelta,
+		/* 134 */ ctComVerRGBIAWYAADelta, invalidDelta, invalidDelta, invalidDelta,
+		/* 138 */ ctNatHorRGBIAWYAADelta, invalidDelta, invalidDelta, invalidDelta,
+		/* 142 */ ctComHorRGBIAWYAADelta, invalidDelta, invalidDelta, invalidDelta,
+		/* 146 */ ctNatVerBGRIAWYAADelta, invalidDelta, invalidDelta, invalidDelta,
+		/* 150 */ ctComVerBGRIAWYAADelta, invalidDelta, invalidDelta, invalidDelta,
+		/* 154 */ ctNatHorBGRIAWYAADelta, invalidDelta, invalidDelta, invalidDelta,
+		/* 158 */ ctComHorBGRIAWYAADelta, invalidDelta, invalidDelta, invalidDelta,
+				  invalidDelta, invalidDelta, invalidDelta, invalidDelta, 
+				  invalidDelta, invalidDelta, invalidDelta, invalidDelta, 
+				  invalidDelta, invalidDelta, invalidDelta, invalidDelta, 
+				  invalidDelta, invalidDelta, invalidDelta, invalidDelta, 
+				  invalidDelta, invalidDelta, invalidDelta, invalidDelta, 
+				  invalidDelta, invalidDelta, invalidDelta, invalidDelta, 
+				  invalidDelta, invalidDelta, invalidDelta, invalidDelta, 
+				  invalidDelta, invalidDelta, invalidDelta, invalidDelta, 
+		/* 194 */ ctNatVerRGBFAWYAADelta, invalidDelta, invalidDelta, invalidDelta,
+		/* 198 */ ctComVerRGBFAWYAADelta, invalidDelta, invalidDelta, invalidDelta,
+		/* 202 */ ctNatHorRGBFAWYAADelta, invalidDelta, invalidDelta, invalidDelta,
+		/* 206 */ ctComHorRGBFAWYAADelta, invalidDelta, invalidDelta, invalidDelta,
+		/* 210 */ ctNatVerBGRFAWYAADelta, invalidDelta, invalidDelta, invalidDelta,
+		/* 214 */ ctComVerBGRFAWYAADelta, invalidDelta, invalidDelta, invalidDelta,
+		/* 218 */ ctNatHorBGRFAWYAADelta, invalidDelta, invalidDelta, invalidDelta,
+		/* 222 */ ctComHorBGRFAWYAADelta, invalidDelta
 	};
 
-	return 0 <= byte && byte < 0xE0 ? deltaColorOfByte[byte] : illegalDelta;
+	return 0 <= byte && byte < 0xE0 ? deltaColorOfByte[byte] : invalidDelta;
 } // DeltaColorOfByte
 
 DeltaColor DeltaColorOfOptions(bool grayScale, bool clearType, bool clearTypeCompWidth, /* bool clearTypeVertRGB, */ bool clearTypeBGR, bool clearTypeFract, bool clearTypeYAA, bool clearTypeGray) {
@@ -391,12 +391,12 @@ void TTSourceEngine::AssertFreeProjVector(TTVDirection dir) {
 			swprintf(code,L"CALL[], %i",this->fnBias + setTTVtoYAdjItalDirFn);
 			break;
 		default:
-			swprintf(code,L"/* illegal TT vector direction */");
+			swprintf(code,L"/* invalid TT vector direction */");
 			break;
 		}
 		this->Emit(code);
-		this->ttv[fv].dir = fvDir; this->ttv[fv].from = this->ttv[fv].to = illegalKnotNum;
-		this->ttv[pv].dir = pvDir; this->ttv[pv].from = this->ttv[pv].to = illegalKnotNum;
+		this->ttv[fv].dir = fvDir; this->ttv[fv].from = this->ttv[fv].to = invalidKnotNum;
+		this->ttv[pv].dir = pvDir; this->ttv[pv].from = this->ttv[pv].to = invalidKnotNum;
 		this->usedpv = false;
 	}
 } // TTSourceEngine::AssertFreeProjVector
@@ -412,7 +412,7 @@ void TTSourceEngine::AssertTTVonLine(TTVector ttv, short parent0, short parent1,
 	if (dir < diagDir) {
 		if (dir != v->dir) {
 			swprintf(buf,L"S%cVTCA[%c]",ttv == fv ? L'F' : L'P',L'X' + (dir == yRomanDir)); this->Emit(buf);
-			v->dir = dir; v->from = v->to = illegalKnotNum;
+			v->dir = dir; v->from = v->to = invalidKnotNum;
 			if (ttv > fv) this->usedpv = ttv == dpv;
 		}
 	} else {
@@ -435,14 +435,14 @@ void TTSourceEngine::AssertFVonCA(bool y) {
 	Vector P0 = {0, 0}, P1 = {0, 0};
 	
 	if (y) P1.y = 1; else P1.x = 1;
-	this->AssertTTVonLine(fv,illegalKnotNum,illegalKnotNum,P0,P1,false);
+	this->AssertTTVonLine(fv,invalidKnotNum,invalidKnotNum,P0,P1,false);
 } // TTSourceEngine::AssertFVonCA
 
 void TTSourceEngine::AssertPVonCA(bool y) {
 	Vector P0 = {0, 0}, P1 = {0, 0};
 	
 	if (y) P1.y = 1; else P1.x = 1;
-	this->AssertTTVonLine(pv,illegalKnotNum,illegalKnotNum,P0,P1,false);
+	this->AssertTTVonLine(pv,invalidKnotNum,invalidKnotNum,P0,P1,false);
 } // TTSourceEngine::AssertPVonCA
 
 void TTSourceEngine::AssertFVonPV() {
@@ -471,7 +471,7 @@ void TTSourceEngine::AssertRefPoint(short rp, short knot) {
 		}
 		this->rp[rp] = knot;
 	}
-	if (rp == 0) this->lastChild = illegalKnotNum;
+	if (rp == 0) this->lastChild = invalidKnotNum;
 } // TTSourceEngine::AssertRefPoint
 
 void TTSourceEngine::AssertRefPointPair(short rp0, short rp1, short knot0, short knot1) {
@@ -628,24 +628,24 @@ void TTSourceEngine::Else(void) {
 void TTSourceEngine::End(bool invalidateRefPoints) {
 	this->Emit( L"#END");
 	this->Emit( L"EIF[]");
-	this->ttv[fv].dir = diagDir; this->ttv[fv].from = this->ttv[fv].to = illegalKnotNum; // assume any kind of side-effect, cf. InitTTEngine(true)
+	this->ttv[fv].dir = diagDir; this->ttv[fv].from = this->ttv[fv].to = invalidKnotNum; // assume any kind of side-effect, cf. InitTTEngine(true)
 	this->ttv[pv] = this->ttv[fv];
 	this->usedpv = false; // ?
-	if (invalidateRefPoints) this->rp[0] = this->rp[1] = this->rp[2] = illegalKnotNum;
+	if (invalidateRefPoints) this->rp[0] = this->rp[1] = this->rp[2] = invalidKnotNum;
 } // TTSourceEngine::End
 
 void TTSourceEngine::MDAP(bool round, short knot) {
 	wchar_t buf[32];
 	
 	swprintf(buf,L"MDAP[%c], %hi",this->rnd[round],knot); this->Emit(buf);
-	this->rp[0] = this->rp[1] = knot; this->lastChild = illegalKnotNum;
+	this->rp[0] = this->rp[1] = knot; this->lastChild = invalidKnotNum;
 } // TTSourceEngine::MDAP
 
 void TTSourceEngine::MIAP(bool round, short knot, short cvt) {
 	wchar_t buf[32];
 	
 	swprintf(buf,L"MIAP[%c], %hi, %hi",this->rnd[round],knot,cvt); this->Emit(buf);
-	this->rp[0] = this->rp[1] = knot; this->lastChild = illegalKnotNum;
+	this->rp[0] = this->rp[1] = knot; this->lastChild = invalidKnotNum;
 } // TTSourceEngine::MIAP
 
 void TTSourceEngine::MDRP(bool minDist, bool round, short color, short knot) {
@@ -676,7 +676,7 @@ void TTSourceEngine::DMIRP(short knot, short cvt, short pvFrom, short pvTo) {
 	wchar_t buf[64];
 	
 	swprintf(buf,L"CALL[], %hd, %hd, %hd, %hd, %hi",knot,cvt,pvFrom,pvTo,this->fnBias + oldDiagMirpFn); this->Emit(buf);
-	this->rp[1] = this->rp[0]; this->rp[2] = knot; this->lastChild = illegalKnotNum;
+	this->rp[1] = this->rp[0]; this->rp[2] = knot; this->lastChild = invalidKnotNum;
 	this->round = rtg;
 	this->ttv[pv].dir = perpDiagDir; this->ttv[pv].from = pvFrom; this->ttv[pv].to = pvTo;
 	this->usedpv = true;
@@ -957,9 +957,9 @@ void TTSourceEngine::CALL3456(short type, short knot3, short cvt3, short knot2, 
 			break;
 	}
 	this->Emit(buf);
-	this->ttv[fv].dir = yRomanDir; this->ttv[fv].from = this->ttv[fv].to = illegalKnotNum;
+	this->ttv[fv].dir = yRomanDir; this->ttv[fv].from = this->ttv[fv].to = invalidKnotNum;
 	this->ttv[pv] = this->ttv[fv];
-	this->rp[0] = knot1; this->lastChild = illegalKnotNum;
+	this->rp[0] = knot1; this->lastChild = invalidKnotNum;
 	this->rp[1] = knot1;
 	this->rp[2] = knot3;
 } // TTSourceEngine::CALL3456
@@ -968,7 +968,7 @@ void TTSourceEngine::CALL64(short parent, short child, short cvt, bool half, boo
 	wchar_t buf[64];
 	
  	swprintf(buf,L"CALL[], %hi, %hi, %hi, %hi, %hi, %hi",parent,child,cvt,half,flip,this->fnBias + 64); this->Emit(buf);
-	this->rp[0] = this->rp[1] = parent; this->lastChild = illegalKnotNum;
+	this->rp[0] = this->rp[1] = parent; this->lastChild = invalidKnotNum;
 	this->rp[2] = child;
 } // TTSourceEngine::CALL64
 
@@ -977,8 +977,8 @@ void TTSourceEngine::CALL656(bool crissCrossLinks, short knot0, short knot1, sho
 	TTVectorDesc *v;
 	
 	swprintf(buf,L"CALL[], %hi, %hi, %hi, %hi, %hi, %hi, %hi, %hi, %hi",knot0,knot1,knot2,knot3,cvt,storage,(short)xLinks,(short)flip,this->fnBias + 65 + (short)crissCrossLinks); this->Emit(buf);
-	this->rp[0] = this->rp[1] = this->rp[2] = illegalKnotNum; this->lastChild = illegalKnotNum;
-	v = &this->ttv[pv]; v->dir = diagDir; v->from = v->to = illegalKnotNum; // assume any kind of side-effect, cf. InitTTEngine(true)
+	this->rp[0] = this->rp[1] = this->rp[2] = invalidKnotNum; this->lastChild = invalidKnotNum;
+	v = &this->ttv[pv]; v->dir = diagDir; v->from = v->to = invalidKnotNum; // assume any kind of side-effect, cf. InitTTEngine(true)
 	this->ttv[fv] = this->ttv[pv];
 } // TTSourceEngine::CALL656
 
@@ -989,7 +989,7 @@ void TTSourceEngine::CALL678(bool back, short knot, short sameSide, short cvt, s
 	if (back) swprintf(buf,L"CALL[], %hi, %hi, %hi, %hi",knot,sameSide,storage,this->fnBias + 68);
 	else swprintf(buf,L"CALL[], %hi, %hi, %hi, %hi, %hi",knot,sameSide,cvt,storage,this->fnBias + 67);
 	this->Emit(buf);
-	v = &this->ttv[pv]; v->dir = diagDir; v->from = v->to = illegalKnotNum; // assume any kind of side-effect, cf. InitTTEngine(true)
+	v = &this->ttv[pv]; v->dir = diagDir; v->from = v->to = invalidKnotNum; // assume any kind of side-effect, cf. InitTTEngine(true)
 	this->ttv[fv] = this->ttv[pv];
 	this->ttv[pv].dir = yRomanDir; // no reference points changed
 } // TTSourceEngine::CALL678
@@ -1012,8 +1012,8 @@ void TTSourceEngine::CALL6(short knots, short knot[], short targetKnot) {
 	} else if (knots == 1)
 		swprintf(buf,L"CALL[], %hi, %hi, %hi",knot[0],targetKnot,this->fnBias + 6);
 	if (knots > 0) {
-		this->rp[0] = targetKnot; this->lastChild = illegalKnotNum;
-		this->ttv[fv].dir = yRomanDir; this->ttv[fv].from = this->ttv[fv].to = illegalKnotNum;
+		this->rp[0] = targetKnot; this->lastChild = invalidKnotNum;
+		this->ttv[fv].dir = yRomanDir; this->ttv[fv].from = this->ttv[fv].to = invalidKnotNum;
 		this->ttv[pv] = this->ttv[fv];
 		this->Emit(buf);
 	}
@@ -1023,8 +1023,8 @@ void TTSourceEngine::CALL378(short type, short targetKnot) {
 	wchar_t buf[32];
 	
 	swprintf(buf,L"CALL[], %hi, %hi",targetKnot,this->fnBias + type); this->Emit(buf);
-	this->rp[0] = type == 37 ? targetKnot + 1 : targetKnot - 1; this->lastChild = illegalKnotNum;
-	this->ttv[fv].dir = yRomanDir; this->ttv[fv].from = this->ttv[fv].to = illegalKnotNum;
+	this->rp[0] = type == 37 ? targetKnot + 1 : targetKnot - 1; this->lastChild = invalidKnotNum;
+	this->ttv[fv].dir = yRomanDir; this->ttv[fv].from = this->ttv[fv].to = invalidKnotNum;
 	this->ttv[pv] = this->ttv[fv];
 } // TTSourceEngine::CALL378
 
@@ -1044,9 +1044,9 @@ void TTSourceEngine::CALL88(short riseCvt, short runCvt) {
 	
 	swprintf(buf,L"CALL[], %hi, %hi, %hi",riseCvt,runCvt,this->fnBias + italicRiseRunFn);
 	this->Emit(buf);
-	this->rp[0] = this->rp[1] = illegalKnotNum; this->lastChild = illegalKnotNum;
+	this->rp[0] = this->rp[1] = invalidKnotNum; this->lastChild = invalidKnotNum;
 	this->sRound = false; this->round = rtg;
-	this->ttv[fv].dir = xRomanDir; this->ttv[fv].from = this->ttv[fv].to = illegalKnotNum;
+	this->ttv[fv].dir = xRomanDir; this->ttv[fv].from = this->ttv[fv].to = invalidKnotNum;
 	this->ttv[pv] = this->ttv[fv];
 } // TTSourceEngine::CALL88
 
@@ -1056,7 +1056,7 @@ void TTSourceEngine::ResMIAP(short child, short cvt) {
 	swprintf(buf,L"CALL[], %hi, %hi, %hi",child,cvt,this->fnBias + resMIAPFn);
 	this->Emit(buf);
 	
-	this->lastChild = illegalKnotNum; // MSIRP in fpgm, cannot patch code in fpgm...
+	this->lastChild = invalidKnotNum; // MSIRP in fpgm, cannot patch code in fpgm...
 	this->rp[0] = this->rp[1] = this->rp[2] = child; // MSIRP[M] used in fpgm
 } // TTSourceEngine::ResMIAP
 
@@ -1070,16 +1070,16 @@ void TTSourceEngine::ResIPMDAP(TTVDirection pvP, bool postRoundFlag, short paren
 	
 	// SO FAR, WILL NEED TO MAKE MORE GENERAL TO ACCOMODATE fvP and fvC
 	if (postRoundFlag) { // only allowed on ResXIPAnchor
-		this->ttv[fv].dir = xRomanDir; this->ttv[pv].from = this->ttv[pv].to = illegalKnotNum;
+		this->ttv[fv].dir = xRomanDir; this->ttv[pv].from = this->ttv[pv].to = invalidKnotNum;
 		this->ttv[fv] = this->ttv[pv];
 		this->rp[1] = child;
 	} else {
-		this->ttv[pv].dir = pvP; this->ttv[pv].from = this->ttv[pv].to = illegalKnotNum;
+		this->ttv[pv].dir = pvP; this->ttv[pv].from = this->ttv[pv].to = invalidKnotNum;
 		this->ttv[fv] = this->ttv[pv];
 		this->rp[1] = parent0;
 	}
 	this->usedpv = false;
-	this->lastChild = illegalKnotNum;
+	this->lastChild = invalidKnotNum;
 	this->rp[0] = this->rp[2] = child;
 	parent1;
 } // TTSourceEngine::ResIPMDAP
@@ -1089,14 +1089,14 @@ void TTSourceEngine::ResMIRP(short parent, short child, short cvt, bool useMinDi
 	int32_t pos;
 	wchar_t buf[64];
 	
-	useCvt = cvt != illegalCvtNum;
+	useCvt = cvt != invalidCvtNum;
 	pos = swprintf(buf,L"CALL[], %hi, %hi",parent,child);
 	if (useCvt) pos += swprintf(&buf[pos],L", %hi",cvt);
 	pos += swprintf(&buf[pos],L", %hi",this->fnBias + resMIRPFn00 + 2*(int32_t)useCvt + (int32_t)useMinDist);
 
 	this->Emit(buf);
 	
-	this->lastChild = illegalKnotNum; // MSIRP in fpgm, cannot patch code in fpgm...
+	this->lastChild = invalidKnotNum; // MSIRP in fpgm, cannot patch code in fpgm...
 	this->rp[1] = parent;
 	this->rp[0] = this->rp[2] = child; // MSIRP[M] used in fpgm
 } // TTSourceEngine::ResMIRP
@@ -1107,10 +1107,10 @@ void TTSourceEngine::ResIPMIRP(TTVDirection pvGP, short strokeOptimizationFlag, 
 	swprintf(buf,L"CALL[], %hi, %hi, %hi, %hi, %hi, %hi, %hi, %hi",pvGP,grandParent0,parent,child,cvt,grandParent1,strokeOptimizationFlag,this->fnBias + resIPMIRPFn);
 	this->Emit(buf);
 	
-	this->ttv[pv].dir = (TTVDirection)((int32_t)pvGP % 2); this->ttv[pv].from = this->ttv[pv].to = illegalKnotNum;
+	this->ttv[pv].dir = (TTVDirection)((int32_t)pvGP % 2); this->ttv[pv].from = this->ttv[pv].to = invalidKnotNum;
 	this->ttv[fv] = this->ttv[pv]; // SO FAR, WILL NEED TO MAKE MORE GENERAL TO ACCOMODATE fvP and fvC
 	this->usedpv = false;
-	this->lastChild = illegalKnotNum;
+	this->lastChild = invalidKnotNum;
 	this->rp[0] = this->rp[1] = this->rp[2] = parent; // parent SRP0[]ed and MSIRP[m]ed last in emulate interpolation of median
 } // TTSourceEngine::ResIPMIRP
 
@@ -1130,8 +1130,8 @@ void TTSourceEngine::ResDDMIRP(short parent0, short child0, TTVectorDesc fv0, sh
 		swprintf(&buf[pos],L"%hi, %hi, %hi, %hi, %hi",fv0.from,fv0.to,fv1.from,fv1.to,this->fnBias + resDDMIRP3Fn); 
 	this->Emit(buf);
 
-	this->lastChild = illegalKnotNum;
-	this->rp[0] = parent0; // this->rp[1] = this->rp[2] = illegalKnotNum; unchanged
+	this->lastChild = invalidKnotNum;
+	this->rp[0] = parent0; // this->rp[1] = this->rp[2] = invalidKnotNum; unchanged
 	this->ttv[fv] = fv1;
 	this->ttv[pv].dir = perpDiagDir; this->ttv[pv].from = parent0; this->ttv[pv].to = child1;
 	this->usedpv = false;
@@ -1143,10 +1143,10 @@ void TTSourceEngine::ResIPDMIRP(TTVDirection pvGP, short grandParent0, short par
 	swprintf(buf,L"CALL[], %hi, %hi, %hi, %hi, %hi, %hi, %hi, %hi, %hi, %hi",pvGP,grandParent0,parent0,child0,cvt0,parent1,child1,cvt1,grandParent1,this->fnBias + resIPDMIRPFn);
 	this->Emit(buf);
 
-	this->ttv[pv].dir = (TTVDirection)((int32_t)pvGP % 2); this->ttv[pv].from = this->ttv[pv].to = illegalKnotNum;
+	this->ttv[pv].dir = (TTVDirection)((int32_t)pvGP % 2); this->ttv[pv].from = this->ttv[pv].to = invalidKnotNum;
 	this->ttv[fv] = this->ttv[pv]; // so far; may have to make more general to accomodate generalized freedom vectors used by the last knot moved, or have fn reset state to pvGP
 	this->usedpv = false;
-	this->lastChild = illegalKnotNum;
+	this->lastChild = invalidKnotNum;
 	this->rp[0] = this->rp[1] = this->rp[2] = parent1; // parent1 SRP0[]ed and MSIRP[m]ed last in symDistFn
 } // TTSourceEngine::ResIPDMIRP
 
@@ -1169,7 +1169,7 @@ void TTSourceEngine::ResIPDDMIRP(TTVDirection pvGP, short grandParent0, short pa
 	this->ttv[fv] = fv1;
 	this->ttv[pv].dir = perpDiagDir; this->ttv[pv].from = parent0; this->ttv[pv].to = parent1;
 	this->usedpv = false;
-	this->lastChild = illegalKnotNum;
+	this->lastChild = invalidKnotNum;
 	this->rp[0] = this->rp[1] = this->rp[2] = child1; // child1 MSIRP[m]ed last to re-center the median after asymmetric linking
 } // TTSourceEngine::ResIPDDMIRP
 
@@ -1179,13 +1179,13 @@ void TTSourceEngine::ResIIPDMIRP(short grandParent0, short parent0, short child0
 	swprintf(buf,L"CALL[], %hi, %hi, %hi, %hi, %hi, %hi, %hi, %hi, %hi",grandParent0,grandParent1,parent0,parent1,child0,child1,cvt0,cvt1,this->fnBias + resIIPDMIRPFn);
 	this->Emit(buf);
 
-	this->lastChild = illegalKnotNum;
+	this->lastChild = invalidKnotNum;
 
-	this->rp[0] = this->rp[1] = this->rp[2] = illegalKnotNum; // because don't know which branch taken
+	this->rp[0] = this->rp[1] = this->rp[2] = invalidKnotNum; // because don't know which branch taken
 
 	this->round = rtg;
-	this->ttv[pv].dir = diagDir; this->ttv[pv].from = this->ttv[pv].to = illegalKnotNum; // branch may or may not have been taken
-	this->ttv[fv].dir = xRomanDir; this->ttv[fv].from = this->ttv[fv].to = illegalKnotNum;
+	this->ttv[pv].dir = diagDir; this->ttv[pv].from = this->ttv[pv].to = invalidKnotNum; // branch may or may not have been taken
+	this->ttv[fv].dir = xRomanDir; this->ttv[fv].from = this->ttv[fv].to = invalidKnotNum;
 	this->usedpv = false;
 } // TTSourceEngine::ResIIPDMIRP
 
@@ -1308,7 +1308,7 @@ void TTSourceEngine::SetAspectRatioFlag(void) {
 	this->Emit(L"/* Square aspect ratio? */");
 	swprintf(code,L"CALL[], %hi",this->fnBias + aspectRatioFn); this->Emit(code);
 	this->Emit(L"");
-	this->ttv[fv].dir = xRomanDir; this->ttv[fv].from = this->ttv[fv].to = illegalKnotNum;
+	this->ttv[fv].dir = xRomanDir; this->ttv[fv].from = this->ttv[fv].to = invalidKnotNum;
 	this->ttv[pv] = this->ttv[fv]; this->ttv[pv].dir = yRomanDir;
 	this->usedpv = false;
 } // TTSourceEngine::SetAspectRatioFlag
@@ -1413,23 +1413,23 @@ void TTSourceEngine::InitTTEngineState(bool forNewGlyph) {
 		this->minDist = one6;
 		this->sRound = false;
 		this->round = rtg;
-		this->ttv[fv].dir = xRomanDir; this->ttv[fv].from = this->ttv[fv].to = illegalKnotNum;
+		this->ttv[fv].dir = xRomanDir; this->ttv[fv].from = this->ttv[fv].to = invalidKnotNum;
 		this->ttv[pv] = this->ttv[fv];
 		this->usedpv = false;
 		this->autoFlip = true;
 		this->deltaBase = defaultDeltaBase; this->deltaShift = defaultDeltaShift;
-		this->lastChild = illegalKnotNum;
+		this->lastChild = invalidKnotNum;
 	} else { // after Call or Inline, assume any kind of side-effect
-		this->rp[0] = this->rp[1] = this->rp[2] = illegalKnotNum;
+		this->rp[0] = this->rp[1] = this->rp[2] = invalidKnotNum;
 		this->minDist = -1;
 		this->sRound = false;
 		this->round = rnone;
-		this->ttv[fv].dir = diagDir; this->ttv[fv].from = this->ttv[fv].to = illegalKnotNum;
+		this->ttv[fv].dir = diagDir; this->ttv[fv].from = this->ttv[fv].to = invalidKnotNum;
 		this->ttv[pv] = this->ttv[fv];
 		this->usedpv = false; // ?
 		this->autoFlip = (bool)-1;
 		this->deltaBase = -48; this->deltaShift = -1;
-		this->lastChild = illegalKnotNum;
+		this->lastChild = invalidKnotNum;
 	}
 } // TTSourceEngine::InitTTEngineState
 

--- a/src/TTEngine.h
+++ b/src/TTEngine.h
@@ -22,7 +22,7 @@
 
 #define maxAsmSize 0x2000L
 
-#define illegalKnotNum (-1)
+#define invalidKnotNum (-1)
 
 typedef enum {rthg = 0, rtdg, rtg, rdtg, rutg, roff, rnone} Rounding;
 

--- a/src/TTFont.cpp
+++ b/src/TTFont.cpp
@@ -575,13 +575,13 @@ bool TrueTypeFont::Read(File *file, TrueTypeGlyph *glyph, short *platformID, sho
 	if (!this->SetSfnt(*platformID, *encodingID, errMsg)) return false;
 
 	// not the smartest way to get these numbers, another historical legacy
-	if ((glyphIndex = this->GlyphIndexOf(L'H')) == ILLEGAL_GLYPH_INDEX) this->capHeight = this->unitsPerEm;
+	if ((glyphIndex = this->GlyphIndexOf(L'H')) == INVALID_GLYPH_INDEX) this->capHeight = this->unitsPerEm;
 	else if (this->GetGlyph(glyphIndex,glyph,errMsg)) this->capHeight = glyph->ymax;
 	else return false;
-	if ((glyphIndex = this->GlyphIndexOf(L'x')) == ILLEGAL_GLYPH_INDEX) this->xHeight = this->unitsPerEm;
+	if ((glyphIndex = this->GlyphIndexOf(L'x')) == INVALID_GLYPH_INDEX) this->xHeight = this->unitsPerEm;
 	else if (this->GetGlyph(glyphIndex,glyph,errMsg)) this->xHeight = glyph->ymax;
 	else return false;
-	if ((glyphIndex = this->GlyphIndexOf(L'p')) == ILLEGAL_GLYPH_INDEX) this->descenderHeight = 0;
+	if ((glyphIndex = this->GlyphIndexOf(L'p')) == INVALID_GLYPH_INDEX) this->descenderHeight = 0;
 	else if (this->GetGlyph(glyphIndex,glyph,errMsg)) this->descenderHeight = glyph->ymin;
 	else return false;	
 
@@ -752,7 +752,7 @@ bool TrueTypeFont::GetGlyph(int32_t glyphIndex, TrueTypeGlyph *glyph, wchar_t er
 	glyph->ymax = SWAPW(signedWord);		
 	
 	glyph->bluePrint.numComponents = 0;
-	glyph->bluePrint.useMyMetrics = ILLEGAL_GLYPH_INDEX; // use nobody's metrics so far
+	glyph->bluePrint.useMyMetrics = INVALID_GLYPH_INDEX; // use nobody's metrics so far
 
 	if ( numContoursInGlyph < 0  ) {
  		glyph->composite = true;
@@ -798,7 +798,7 @@ bool TrueTypeFont::GetGlyph(int32_t glyphIndex, TrueTypeGlyph *glyph, wchar_t er
 
 			if (flags & USE_MY_METRICS) { 
  				glyph->useMyMetrics = true;
-				if (glyph->bluePrint.useMyMetrics == ILLEGAL_GLYPH_INDEX) glyph->bluePrint.useMyMetrics = cgIdx; // first one wins
+				if (glyph->bluePrint.useMyMetrics == INVALID_GLYPH_INDEX) glyph->bluePrint.useMyMetrics = cgIdx; // first one wins
  			}
  			if ( flags & ARG_1_AND_2_ARE_WORDS ) {
  				/* arg 1 and 2 */
@@ -1076,7 +1076,7 @@ int32_t TrueTypeFont::GlyphIndexOf(uint32_t charCode) {
 	map.unicode = charCode;
 
 	if(!std::binary_search(glyphIndexMap->begin(), glyphIndexMap->end(), map, Compare_UniGlyphMap))
-		return ILLEGAL_GLYPH_INDEX; 
+		return INVALID_GLYPH_INDEX; 
 
 	it = std::lower_bound(glyphIndexMap->begin(), glyphIndexMap->end(), map, Compare_UniGlyphMap); 
 
@@ -1094,7 +1094,7 @@ bool TrueTypeFont::GlyphIndecesOf(wchar_t textString[], int32_t maxNumGlyphIndec
 			ch = textString[i++]; dec = 0;
 			while (ch && ch != L'^') {
 				if (L'0' <= ch && ch <= L'9') dec = 10*dec + (int32_t)(ch - L'0');
-				else { swprintf(errMsg,L"illegal decimal digit in glyph index"); return false; }
+				else { swprintf(errMsg,L"invalid decimal digit in glyph index"); return false; }
 				ch = textString[i++];
 			}
 			if (ch == L'^') ch = textString[i++];
@@ -1105,7 +1105,7 @@ bool TrueTypeFont::GlyphIndecesOf(wchar_t textString[], int32_t maxNumGlyphIndec
 				if (L'0' <= ch && ch <= L'9') hex = 16*hex + (int32_t)(ch - L'0');
 				else if (L'A' <= ch && ch <= L'F') hex = 16*hex + (int32_t)(ch - L'A' + 10);
 				else if (L'a' <= ch && ch <= L'f') hex = 16*hex + (int32_t)(ch - L'a' + 10);
-				else { swprintf(errMsg,L"illegal hexadecimal digit in glyph index"); return false; }
+				else { swprintf(errMsg,L"invalid hexadecimal digit in glyph index"); return false; }
 				ch = textString[i++];
 			}
 			if (ch == L'~') ch = textString[i++];

--- a/src/TTFont.h
+++ b/src/TTFont.h
@@ -29,7 +29,7 @@
 //#define TOPSIDEBEARING      2
 //#define BOTTOMSIDEBEARING   3
 
-#define ILLEGAL_GLYPH_INDEX	0xffff
+#define INVALID_GLYPH_INDEX	0xffff
 
 #define maxNumCharCodes			0x10000
 
@@ -218,7 +218,7 @@ typedef struct {
 
 typedef struct {
 	unsigned short numComponents;
-	unsigned short useMyMetrics; // or ILLEGAL_GLYPH_INDEX if nobody's metrics
+	unsigned short useMyMetrics; // or INVALID_GLYPH_INDEX if nobody's metrics
 	TrueTypeComponent component[MAXNUMCOMPONENTS];
 } TrueTypeBluePrint;
 

--- a/src/TTGenerator.cpp
+++ b/src/TTGenerator.cpp
@@ -238,7 +238,7 @@ private:
 	FVMTDirection CalcAlignFVMT(FVOverride fv, short parent0, short parent1, short child, RVector alignDirection, short *refPoint0, short *refPoint1);
 	void AssertFVMT(FVMTDirection fvmt, short point0, short point1);
 	void Touched(short knot, TTVDirection dir);
-	short TheCvt(short parent, short child, LinkColor color, LinkDirection direction, CvtCategory category, short distance); // color, category, and distance: -1 or illegalCvtNum for default
+	short TheCvt(short parent, short child, LinkColor color, LinkDirection direction, CvtCategory category, short distance); // color, category, and distance: -1 or invalidCvtNum for default
 	void DoVacuFormRound(void);
 };
 
@@ -626,7 +626,7 @@ void TTSourceGenerator::Link(bool y, bool dist, ProjFreeVector *projFreeVector, 
 		this->tt->MDAP(true,child);
 	}
 	if (this->tt) this->Touched(child,projFreeVector->fv[0].dir);	
-	*actualCvt = lsbLink || rsbLink ? illegalCvtNum : cvt;
+	*actualCvt = lsbLink || rsbLink ? invalidCvtNum : cvt;
 } /* TTSourceGenerator::Link */
 
 /***** have to test this on the visual level, because we might end up with the following scenario:
@@ -1626,12 +1626,12 @@ void TTSourceGenerator::Serif(bool forward, short type, short knots, short knot[
 			*****/
 			if (this->tt) {
 				swprintf(buf,L"/* Round serif %hi %hi %hi %hi %hi %hi %hi */",knot[0],knot[1],knot[2],knot[3],knot[4],knot[5],knot[6]); this->tt->Emit(buf);
-				this->Link(true, false,&this->yRomanPV,false,knot[0],knot[1],cvtSerifOther,illegalCvtNum,1,ppem,dist,&actualCvt,error);
-				this->Link(true, false,&this->yRomanPV,false,knot[0],knot[3],cvtSerifOther,illegalCvtNum,0,NULL,NULL,&actualCvt,error);
-				this->Link(true, false,&this->yRomanPV,false,knot[3],knot[4],cvtSerifOther,illegalCvtNum,1,ppem,dist,&actualCvt,error);
-				this->Link(false,false,&this->xRomanPV,false,knot[4],knot[5],cvtSerifThin, illegalCvtNum,1,ppem,dist,&actualCvt,error);
-				this->Link(false,false,&this->xRomanPV,false,knot[4],knot[3],cvtSerifOther,illegalCvtNum,0,NULL,NULL,&actualCvt,error);
-				this->Link(false,false,&this->xRomanPV,false,knot[3],knot[2],cvtSerifThin, illegalCvtNum,1,ppem,dist,&actualCvt,error);
+				this->Link(true, false,&this->yRomanPV,false,knot[0],knot[1],cvtSerifOther,invalidCvtNum,1,ppem,dist,&actualCvt,error);
+				this->Link(true, false,&this->yRomanPV,false,knot[0],knot[3],cvtSerifOther,invalidCvtNum,0,NULL,NULL,&actualCvt,error);
+				this->Link(true, false,&this->yRomanPV,false,knot[3],knot[4],cvtSerifOther,invalidCvtNum,1,ppem,dist,&actualCvt,error);
+				this->Link(false,false,&this->xRomanPV,false,knot[4],knot[5],cvtSerifThin, invalidCvtNum,1,ppem,dist,&actualCvt,error);
+				this->Link(false,false,&this->xRomanPV,false,knot[4],knot[3],cvtSerifOther,invalidCvtNum,0,NULL,NULL,&actualCvt,error);
+				this->Link(false,false,&this->xRomanPV,false,knot[3],knot[2],cvtSerifThin, invalidCvtNum,1,ppem,dist,&actualCvt,error);
 			}
 			break;
 		case 1: /*****
@@ -1656,11 +1656,11 @@ void TTSourceGenerator::Serif(bool forward, short type, short knots, short knot[
 			*****/
 			if (this->tt) {
 				swprintf(buf,L"/* Triangular serif %hi %hi %hi %hi */",knot[0],knot[1],knot[2],knot[3]); this->tt->Emit(buf);
-				this->Link(true, false,&this->yRomanPV,false,knot[3],knot[2],cvtSerifCurveHeight,illegalCvtNum,0,NULL,NULL,&actualCvt,error);
-				this->Link(true, false,&this->yRomanPV,false,knot[2],knot[1],cvtSerifThin,  		illegalCvtNum,1,ppem,dist,&actualCvt,error);
-				this->Link(true, false,this->attrib[knot[0]].iStroke ? &this->yAdjItalPV : &this->yRomanPV,false,knot[2],knot[0],cvtSerifHeight,illegalCvtNum,1,ppem,dist,&actualCvt,error);
+				this->Link(true, false,&this->yRomanPV,false,knot[3],knot[2],cvtSerifCurveHeight,invalidCvtNum,0,NULL,NULL,&actualCvt,error);
+				this->Link(true, false,&this->yRomanPV,false,knot[2],knot[1],cvtSerifThin,  		invalidCvtNum,1,ppem,dist,&actualCvt,error);
+				this->Link(true, false,this->attrib[knot[0]].iStroke ? &this->yAdjItalPV : &this->yRomanPV,false,knot[2],knot[0],cvtSerifHeight,invalidCvtNum,1,ppem,dist,&actualCvt,error);
 									// set vectors to yAdjItalDir if knot[0] is part of an iStroke...
-				this->Link(false,false,&this->xRomanPV,false,knot[0],knot[2],cvtSerifExt,   		illegalCvtNum,0,NULL,NULL,&actualCvt,error);
+				this->Link(false,false,&this->xRomanPV,false,knot[0],knot[2],cvtSerifExt,   		invalidCvtNum,0,NULL,NULL,&actualCvt,error);
 			}
 			break;
 		case 2:
@@ -1755,10 +1755,10 @@ void TTSourceGenerator::Serif(bool forward, short type, short knots, short knot[
 						
 						
 					} else {
-						if (italBase) this->Anchor(false,&this->xRomanPV,knot[1],illegalCvtNum,false,error);
-						this->Link(horzBase,false,horzBase ? &this->yRomanPV : &this->yRomanPV,false,knot[1],knot[2],cvtSerifThin,illegalCvtNum,1,ppem,dist,&actualCvt,error);
-						if (type == 2) this->Link(horzBase,false,horzBase ? &this->yRomanPV : &this->yRomanPV,false,knot[1],knot[3],cvtSerifHeight,illegalCvtNum,1,ppem,dist,&actualCvt,error); // control serif height
-						this->Link(!horzBase,this->attrib[knot[3]].dStroke || this->attrib[knot[3]].iStroke,!horzBase ? &this->yRomanPV : &this->yRomanPV,false,knot[3],knot[1],cvtSerifExt,illegalCvtNum,0,NULL,NULL,&actualCvt,error);
+						if (italBase) this->Anchor(false,&this->xRomanPV,knot[1],invalidCvtNum,false,error);
+						this->Link(horzBase,false,horzBase ? &this->yRomanPV : &this->yRomanPV,false,knot[1],knot[2],cvtSerifThin,invalidCvtNum,1,ppem,dist,&actualCvt,error);
+						if (type == 2) this->Link(horzBase,false,horzBase ? &this->yRomanPV : &this->yRomanPV,false,knot[1],knot[3],cvtSerifHeight,invalidCvtNum,1,ppem,dist,&actualCvt,error); // control serif height
+						this->Link(!horzBase,this->attrib[knot[3]].dStroke || this->attrib[knot[3]].iStroke,!horzBase ? &this->yRomanPV : &this->yRomanPV,false,knot[3],knot[1],cvtSerifExt,invalidCvtNum,0,NULL,NULL,&actualCvt,error);
 					}
 				}
 			} else
@@ -1803,16 +1803,16 @@ void TTSourceGenerator::Serif(bool forward, short type, short knots, short knot[
 				if (this->tt) {
 					swprintf(buf,L"/* " WIDE_STR_FORMAT L" univ-serif %hi %hi %hi %hi */",forward ? L"Forward" : L"Backward",knot[1],knot[2],knot[3],knot[4]); this->tt->Emit(buf);
 					
-					this->Link(horzBase,false,horzBase ? &this->yRomanPV : &this->yRomanPV,false,knot[1],knot[3],cvtSerifThin,illegalCvtNum,1,ppem,dist,&actualCvt,error);
-					this->Link(!horzBase,false,!horzBase ? &this->yRomanPV : &this->yRomanPV,false,knot[4],knot[2],cvtSerifExt,illegalCvtNum,0,NULL,NULL,&actualCvt,error);
+					this->Link(horzBase,false,horzBase ? &this->yRomanPV : &this->yRomanPV,false,knot[1],knot[3],cvtSerifThin,invalidCvtNum,1,ppem,dist,&actualCvt,error);
+					this->Link(!horzBase,false,!horzBase ? &this->yRomanPV : &this->yRomanPV,false,knot[4],knot[2],cvtSerifExt,invalidCvtNum,0,NULL,NULL,&actualCvt,error);
 					link34 = SubV(this->V[knot[3]],this->V[knot[4]]);
 					if (horzBase) {
 						if ((Abs(link34.x) > 0)) { // could compare with a small value
-							this->Link(horzBase,false,horzBase ? &this->yRomanPV : &this->yRomanPV,false,knot[1],knot[4],cvtSerifHeight,illegalCvtNum,1,ppem,dist,&actualCvt,error);
+							this->Link(horzBase,false,horzBase ? &this->yRomanPV : &this->yRomanPV,false,knot[1],knot[4],cvtSerifHeight,invalidCvtNum,1,ppem,dist,&actualCvt,error);
 						}
 					} else {
 						if ((Abs(link34.y) > 0)) {
-							this->Link(horzBase,false,horzBase ? &this->yRomanPV : &this->yRomanPV,false,knot[1],knot[4],cvtSerifHeight,illegalCvtNum,1,ppem,dist,&actualCvt,error);
+							this->Link(horzBase,false,horzBase ? &this->yRomanPV : &this->yRomanPV,false,knot[1],knot[4],cvtSerifHeight,invalidCvtNum,1,ppem,dist,&actualCvt,error);
 						}
 					}
 				}
@@ -1840,7 +1840,7 @@ void TTSourceGenerator::Scoop(short parent0, short child, short parent1, wchar_t
 		swprintf(error,L"cannot accept SCOOP (base differs from horizontal or vertical by %f degrees or more)",(double)strokeFudge);
 	}
 	if (ok)
-		if (this->tt) this->Link(y,false,y ? &this->yRomanPV : &this->yRomanPV,false,parent0,child,cvtScoopDepth,illegalCvtNum,0,NULL,NULL,&actualCvt,error);
+		if (this->tt) this->Link(y,false,y ? &this->yRomanPV : &this->yRomanPV,false,parent0,child,cvtScoopDepth,invalidCvtNum,0,NULL,NULL,&actualCvt,error);
 } /* TTSourceGenerator::Scoop */
 
 void TTSourceGenerator::Smooth(short y, short italicFlag) {
@@ -1944,10 +1944,10 @@ void InitFreeProjVector(TTVDirection pv, ProjFreeVector *projFreeVector) {
 	short i;
 	
 	projFreeVector->pv.dir = pv;
-	projFreeVector->pv.from = projFreeVector->pv.to = illegalKnotNum;
+	projFreeVector->pv.from = projFreeVector->pv.to = invalidKnotNum;
 	for (i = 0; i < maxParams; i++) {
 		projFreeVector->fv[i].dir = pv;
-		projFreeVector->fv[i].from = projFreeVector->fv[i].to = illegalKnotNum;
+		projFreeVector->fv[i].from = projFreeVector->fv[i].to = invalidKnotNum;
 	}
 } // InitFreeProjVector
 
@@ -1970,7 +1970,7 @@ void TTSourceGenerator::InitTTGenerator(TrueTypeFont *font, TrueTypeGlyph *glyph
 	
 	this->xAxis.x = 1; this->yAxis.x = 0; this->slope.x = 0;
 	this->xAxis.y = 0; this->yAxis.y = 1; this->slope.y = 1;
-	this->riseCvt = this->runCvt = illegalCvtNum;
+	this->riseCvt = this->runCvt = invalidCvtNum;
 	this->cosF = cos(Rad(strokeFudge));
 	this->tanF = tan(Rad(strokeFudge));
 	this->cosF0 = cos(Rad(MAXSTROKESIDEANGLEDIFFERENCE));
@@ -2050,7 +2050,7 @@ void TTSourceGenerator::InitCodePathState(void) {
 	for (i = 0; i < this->knots; i++) {
 		attrib = &this->attrib[i];
 		for (j = 0; j < 2; j++) attrib->round[j] = rtg; // default
-		attrib->cvt = illegalCvtNum;
+		attrib->cvt = invalidCvtNum;
 		for (j = 0; j < 2; j++) attrib->touched[j] = false;
 		attrib->dStroke = false;
 		attrib->iStroke = false;

--- a/src/TTGenerator.h
+++ b/src/TTGenerator.h
@@ -15,10 +15,10 @@
 typedef struct {
 	TTVectorDesc pv;
 	TTVectorDesc fv[maxParams];
-//	TTVDirection pv;                             // if pvKnot1 != illegalKnotNum, SDPVTL[r] (!perpPV) or SDPVTL[R] (perpPV)
-//	short pvKnot0,pvKnot1;                       // if pvKnot1 != illegalKnotNum, SDPVTL[?], pvKnot0, pvKnot1
-//	TTVDirection fv[maxParams];                  // if fvKnot1[i] != illegalKnotNum, SFVTL[r] (!perpFV) or SFVTL[R] (perpFV) (for each of the params of Interpolate)
-//	short fvKnot0[maxParams],fvKnot1[maxParams]; // if fvKnot1[i] != illegalKnotNum, SFVTL[?], fvKnot0, fvKnot1 (for each of the params of Interpolate)
+//	TTVDirection pv;                             // if pvKnot1 != invalidKnotNum, SDPVTL[r] (!perpPV) or SDPVTL[R] (perpPV)
+//	short pvKnot0,pvKnot1;                       // if pvKnot1 != invalidKnotNum, SDPVTL[?], pvKnot0, pvKnot1
+//	TTVDirection fv[maxParams];                  // if fvKnot1[i] != invalidKnotNum, SFVTL[r] (!perpFV) or SFVTL[R] (perpFV) (for each of the params of Interpolate)
+//	short fvKnot0[maxParams],fvKnot1[maxParams]; // if fvKnot1[i] != invalidKnotNum, SFVTL[?], fvKnot0, fvKnot1 (for each of the params of Interpolate)
 } ProjFreeVector;
 
 class TTGenerator {

--- a/src/vttcompile.cpp
+++ b/src/vttcompile.cpp
@@ -66,7 +66,7 @@ Application::~Application(void)
 bool Application::OpenFont(std::string fileName, wchar_t errMsg[]) {
 	auto file = std::make_unique<File>();
 
-	this->charCode = this->glyphIndex = ILLEGAL_GLYPH_INDEX;
+	this->charCode = this->glyphIndex = INVALID_GLYPH_INDEX;
 
 	this->fileName = fileName;
 	file->OpenOld(this->fileName.c_str());
@@ -129,7 +129,7 @@ bool Application::GotoGlyph(int32_t code, bool isGlyphIndex) {
 	else {
 		charCode = code;
 		glyphIndex = this->font->GlyphIndexOf(code);
-		if (glyphIndex == ILLEGAL_GLYPH_INDEX) glyphIndex = 0;
+		if (glyphIndex == INVALID_GLYPH_INDEX) glyphIndex = 0;
 	}
 	if (this->glyphIndex != glyphIndex || this->charCode != charCode) {
 		
@@ -485,7 +485,7 @@ bool Application::CompileAll(int32_t* errPos, int32_t* errLen, bool quiet, wchar
 bool Application::BuildFont(StripCommand strip, wchar_t errMsg[]) {
 
 	// If we did not compile and are just here to strip data then perform lazy initialization.
-	if (this->glyphIndex == ILLEGAL_GLYPH_INDEX)
+	if (this->glyphIndex == INVALID_GLYPH_INDEX)
 	{
 		this->glyphIndex = 0;
 		this->charCode = this->font->CharCodeOf(this->glyphIndex);


### PR DESCRIPTION
…se-variants

Done with:
    sed -i -e 's/Illegal/Invalid/g' *.cpp *.h
    sed -i -e 's/illegal/invalid/g' *.cpp *.h
    sed -i -e 's/ILLEGAL/INVALID/g' *.cpp *.h
    sed -i -e 's/legal/valid/g' *.cpp *.h
    sed -i -e 's/Illegal/Invalid/g' doc/*/*.html

Fixes https://github.com/microsoft/VisualTrueType/issues/24