### PR TITLE
TextBuffer backup conversion for old VTT source data

### DIFF
--- a/.github/workflows/py_ext_main.yml
+++ b/.github/workflows/py_ext_main.yml
@@ -35,6 +35,7 @@ jobs:
       - name: Install dependencies
         run: |
              python -m pip install --upgrade pip
+             pip install setuptools
              pip install cibuildwheel
              pip install cython 
         

--- a/src/TextBuffer.cpp
+++ b/src/TextBuffer.cpp
@@ -122,9 +122,20 @@ void TextBuffer::SetText(int32_t textLen, const char text[])
 	}
 	else
 	{
-		std::string str(reinterpret_cast<const char*>(text), textLen);
-		std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
-		std::wstring wstr = converter.from_bytes(str);
+		std::wstring wstr; 
+        std::string str(reinterpret_cast<const char*>(text), textLen);
+		try
+		{			
+			std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
+			wstr = converter.from_bytes(str);
+		}
+        
+        catch (const std::range_error)
+        {	
+            // Some really old VTT source data has sequences that failed above conversion so we do a nieve conversion. 
+            wstr.resize(str.length(), L' '); 
+			std::copy(str.begin(), str.end(), wstr.begin());
+		}
 
 		this->SetText(wstr.length(), wstr.c_str()); 
 	}

--- a/vttcompile/vttcompile.vcxproj
+++ b/vttcompile/vttcompile.vcxproj
@@ -29,26 +29,26 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>


### PR DESCRIPTION
Desktop VTT uses the Windows MultiByteToWideChar() to perform text conversion from source data to wide characters. It appears that when there is problem with the conversion, MultiByteToWideChar() will will not fail but risk bad data. However for this VTT where we support multiple platforms we use std::codecvt_utf8_utf16 which appears to throw or fail with bad conversion. Some super old source data in a font seemed to work on desktop VTT but failed in this compiler. Added a naive conversion of std::codecvt_utf8_utf16 fails. This should be fine because most even really old source data should be ascii. 

This PR also updates the Visual Studio tools set and addresses a Python change on support of setuptools.  