### PR TITLE
Re enable Python 3.13 for project. 

### DIFF
--- a/.github/workflows/py_ext_main.yml
+++ b/.github/workflows/py_ext_main.yml
@@ -3,10 +3,10 @@ name: Python Extension
 on:
   # Triggers the workflow on push or pull request events but only for the main branch
   push:
-    branches: [ main ]
+    branches: [ main, 'work/**' ]
     tags: ["v*.*.*"]
   pull_request:
-    branches: [ main ]
+    branches: [ main, 'work/**' ]
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:  

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ requires = [
 build-backend = "setuptools.build_meta"
 
 [tool.cibuildwheel]
-skip = ["*-manylinux_i686", "pp*", "cp313-*"]
+skip = ["*-manylinux_i686", "pp*"]
 
 test-requires = ["pytest", "fonttools"]
 test-command = "pytest {project}/tests"

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,15 @@ extra_compile_args = []
 if platform.system() != "Windows":
     extra_compile_args.append("-std=c++14")
 
-if platform.system() == "Windows":
+# Check if the operating system is Windows and the Python version is less than 3.13.
+# If both conditions are met, append the "-sdl" flag to the extra_compile_args list
+# to enable additional security checks during compilation.
+#
+# The reason we have to exclude Python 3.13 is Py_UNICODE is deprecated warning and Py_UNICODE
+# is used by Cython array.array that is used in this project.
+# The Cython issue is tracked here:
+# https://github.com/cython/cython/issues/6607
+if platform.system() == "Windows" and sys.version_info < (3, 13):
     extra_compile_args.append("-sdl")
 
 extension = Extension(


### PR DESCRIPTION
Python 3.13 builds failed because "Error C4996: 'Py_UNICODE': deprecated in 3.13". Project does not use this, but we use array.array that uses it. This is technically a warning but on Windows builds we add the "-sdl" flag to extra_compile_args to enable additional security checks during compilation. The sdl flag sets warnings as errors. Temporarily disable flag on 3.13 builds until resolved in Cython. 
https://github.com/cython/cython/issues/6607 